### PR TITLE
FIX: using the correct component for rendering page ui

### DIFF
--- a/src/components/quran/quran-view.tsx
+++ b/src/components/quran/quran-view.tsx
@@ -20,7 +20,7 @@ import {
   VerseHighlight,
   ChapterHeader,
 } from "./types";
-import SuraNameBar from "../../assets/images/sura_name_bar.svg";
+import SuraNameBar from "../../../assets/images/sura_name_bar.svg";
 import { VerseFasel } from "../verse-fasel";
 import { QuranImages } from "../../constants/image-map";
 import { VersePopup } from "./verse-popup";
@@ -186,6 +186,8 @@ export function QuranView({
         pageNumber,
         position: { x, y },
       });
+      setSelectedVerse(verse);
+      setVersePopupVisible(true);
       const event: VersePressEvent = {
         verse,
         page: pageNumber,

--- a/src/screens/mushaf-screen.tsx
+++ b/src/screens/mushaf-screen.tsx
@@ -9,6 +9,7 @@ import {
 import { AudioPlayerBar } from "../components/audio-player-bar";
 import { QuranPage } from "../components/quran-page";
 import { databaseService } from "../services/sqlite-service";
+import { QuranView } from "../components/quran";
 
 const { height, width } = Dimensions.get("window");
 
@@ -72,7 +73,7 @@ export function MushafScreen() {
         removeClippedSubviews
         renderItem={({ item }) => (
           <View style={{ height: height - 60, width }}>
-            <QuranPage
+            <QuranView
               activeChapter={currentChapter}
               activeVerse={activeVerse}
               pageNumber={item}


### PR DESCRIPTION
### Summary
- Replaced the currently used QuranPage component with QuranView, as the latter contains the logic referenced in this issue and was not being utilized.

- Fixed onVerseLongPress by adding the necessary state updates to handle highlighting and opening the popup for the active verse.

### Changes

- Swap QuranPage → QuranView.

- Update state handling in onVerseLongPress.

### Result
<img width="798" height="1600" alt="image" src="https://github.com/user-attachments/assets/02f9d071-adb6-4e3e-a1f1-d4c5561413cc" />



### Notes
renderVerseContentAreas could be further optimized by leveraging verse marker positions and line heights, as current hitboxes are slightly misaligned.
<img width="800" height="1600" alt="image" src="https://github.com/user-attachments/assets/51dcf0f4-950c-44c6-ba3f-a1559c91ae34" />
