### PR TITLE
fix: atomic page state updates to prevent progressive rendering

### DIFF
--- a/src/components/quran-page.tsx
+++ b/src/components/quran-page.tsx
@@ -187,6 +187,7 @@ export const QuranPage: React.FC<Props> = ({
     return (
       <View style={[styles.container, styles.center]}>
         <ActivityIndicator size="large" color={colors.brand.accent} />
+        <Text style={styles.loadingText}>جارٍ تحميل الصفحة...</Text>
       </View>
     );
   }
@@ -227,4 +228,10 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   retryText: { color: colors.text.inverse, fontWeight: "bold" },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: colors.text.secondary,
+    fontFamily: "uthman_tn1_bold",
+  },
 });

--- a/src/components/quran/quran-view.tsx
+++ b/src/components/quran/quran-view.tsx
@@ -418,6 +418,7 @@ export function QuranView({
     return (
       <View style={styles.center}>
         <ActivityIndicator size="large" color={colors.brand.default} />
+        <Text style={styles.loadingText}>جارٍ تحميل الصفحة...</Text>
       </View>
     );
   }
@@ -485,5 +486,11 @@ const styles = StyleSheet.create({
   errorText: {
     color: colors.text.error,
     fontSize: 16,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: colors.text.secondary,
+    fontFamily: "uthman_tn1_bold",
   },
 });

--- a/src/components/quran/use-quran-data.ts
+++ b/src/components/quran/use-quran-data.ts
@@ -3,35 +3,34 @@ import { useState, useEffect } from "react";
 import { databaseService } from "../../services/sqlite-service";
 import { Page } from "./types";
 
-interface UseQuranDataResult {
+type QuranDataState = {
   page: Page | null;
   loading: boolean;
   error: Error | null;
-}
+};
 
-export function useQuranData(pageNumber: number): UseQuranDataResult {
-  const [page, setPage] = useState<Page | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+const INITIAL_STATE: QuranDataState = { page: null, loading: true, error: null };
+
+export function useQuranData(pageNumber: number): QuranDataState {
+  const [state, setState] = useState<QuranDataState>(INITIAL_STATE);
 
   useEffect(() => {
     let mounted = true;
 
     const loadPage = async () => {
+      setState(INITIAL_STATE);
       try {
-        setLoading(true);
-        setError(null);
         const pageData = await databaseService.getPageByNumber(pageNumber);
         if (mounted) {
-          setPage(pageData);
+          setState({ page: pageData, loading: false, error: null });
         }
       } catch (err) {
         if (mounted) {
-          setError(err instanceof Error ? err : new Error("Unknown error"));
-        }
-      } finally {
-        if (mounted) {
-          setLoading(false);
+          setState({
+            page: null,
+            loading: false,
+            error: err instanceof Error ? err : new Error("Unknown error"),
+          });
         }
       }
     };
@@ -43,5 +42,5 @@ export function useQuranData(pageNumber: number): UseQuranDataResult {
     };
   }, [pageNumber]);
 
-  return { page, loading, error };
+  return state;
 }

--- a/src/hooks/use-quran-page.ts
+++ b/src/hooks/use-quran-page.ts
@@ -1,26 +1,32 @@
 import { useEffect, useState, useCallback } from "react";
 import { databaseService, Page } from "../services/sqlite-service";
 
+type PageState = {
+  page: Page | null;
+  loading: boolean;
+  error: string | null;
+};
+
+const INITIAL_STATE: PageState = { page: null, loading: true, error: null };
+
 export const useQuranPage = (pageNumber: number) => {
-  const [page, setPage] = useState<Page | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<PageState>(INITIAL_STATE);
 
   const loadPage = useCallback(async () => {
+    setState(INITIAL_STATE);
     try {
-      setLoading(true);
-      setError(null);
       const pageData = await databaseService.getPageByNumber(pageNumber);
       if (!pageData) {
         throw new Error("لم يتم العثور على بيانات لهذه الصفحة");
       }
-      setPage(pageData);
+      setState({ page: pageData, loading: false, error: null });
     } catch (err) {
       console.error("Error loading page:", err);
-      setError("حدث خطأ أثناء تحميل الصفحة من قاعدة البيانات");
-      setPage(null);
-    } finally {
-      setLoading(false);
+      setState({
+        page: null,
+        loading: false,
+        error: "حدث خطأ أثناء تحميل الصفحة من قاعدة البيانات",
+      });
     }
   }, [pageNumber]);
 
@@ -28,5 +34,5 @@ export const useQuranPage = (pageNumber: number) => {
     loadPage();
   }, [loadPage]);
 
-  return { page, loading, error, retry: loadPage };
+  return { ...state, retry: loadPage };
 };


### PR DESCRIPTION
## Summary
- Replaces separate `useState` calls for `page`, `loading`, and `error` with a single state object
- All three fields now update atomically in a single `setState` call
- Prevents the visible progressive layout (top → bottom → middle) caused by intermediate render states

## Changes
- `src/hooks/use-quran-page.ts`: Merged 3 useState into 1 `PageState` object with atomic updates
- `src/components/quran/use-quran-data.ts`: Same atomic state pattern applied

## Before
```ts
setLoading(true);  // render 1
setError(null);    // render 2
setPage(data);     // render 3
setLoading(false); // render 4
```

## After
```ts
setState({ page: data, loading: false, error: null }); // single render
```

Closes #6