### PR TITLE
feat: centralize state management with Zustand

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react": "19.1.0",
     "react-native": "0.81.5",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-svg": "15.12.1"
+    "react-native-svg": "15.12.1",
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@eslint-react/eslint-plugin": "^2.13.0",

--- a/src/components/audio-player-bar.tsx
+++ b/src/components/audio-player-bar.tsx
@@ -1,61 +1,51 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { View, Button, StyleSheet, Text } from "react-native";
 import { useAudioPlayer } from "expo-audio";
 import { loadTiming } from "../services/ayah-timing-service";
 import { colors } from "../theme";
+import { useMushafStore } from "../store/mushaf-store";
 
-interface Props {
-  chapterNumber: number;
-  onVerseChange: (verseNumber: number) => void;
-}
+export const AudioPlayerBar: React.FC = () => {
+  const currentChapter = useMushafStore((s) => s.currentChapter);
+  const setActiveVerse = useMushafStore((s) => s.setActiveVerse);
+  const isPlaying = useMushafStore((s) => s.isPlaying);
+  const setIsPlaying = useMushafStore((s) => s.setIsPlaying);
 
-export const AudioPlayerBar: React.FC<Props> = ({
-  chapterNumber,
-  onVerseChange,
-}) => {
-  const paddedChapter = chapterNumber.toString().padStart(3, "0");
+  const paddedChapter = currentChapter.toString().padStart(3, "0");
   const url = `https://server6.mp3quran.net/akdr/${paddedChapter}.mp3`;
 
   const player = useAudioPlayer(url);
-  const [timing, setTiming] = useState<any>(null);
-  const [isPlaying, setIsPlaying] = useState(false);
 
   useEffect(() => {
+    let timingData: any = null;
+
     loadTiming(1).then((data) => {
       if (data) {
-        const chapterData = data.chapters.find(
-          (c: any) => c.id === chapterNumber,
+        timingData = data.chapters.find(
+          (c: any) => c.id === currentChapter,
         );
-        setTiming(chapterData);
       }
     });
-  }, [chapterNumber]);
 
-  useEffect(() => {
     const interval = setInterval(() => {
-      // Check if player is playing. Note: player.playing might be a getter.
-      // We assume player object is stable but its properties change.
-      // However, hooks usually trigger re-render on change if they are stateful.
-      // If useAudioPlayer returns a plain object ref, we need to poll.
-
       const playing = player.playing;
       if (playing !== isPlaying) {
         setIsPlaying(playing);
       }
 
-      if (playing && timing) {
+      if (playing && timingData) {
         const timeMs = player.currentTime * 1000;
-        const verse = timing.aya_timing.find(
+        const verse = timingData.aya_timing.find(
           (t: any) => timeMs >= t.start_time && timeMs < t.end_time,
         );
         if (verse) {
-          onVerseChange(verse.ayah);
+          setActiveVerse(verse.ayah);
         }
       }
     }, 200);
 
     return () => clearInterval(interval);
-  }, [player, timing, isPlaying, onVerseChange]);
+  }, [player, currentChapter, isPlaying, setActiveVerse, setIsPlaying]);
 
   const togglePlay = () => {
     if (player.playing) {

--- a/src/screens/mushaf-screen.tsx
+++ b/src/screens/mushaf-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import {
   Dimensions,
   FlatList,
@@ -11,6 +11,7 @@ import { QuranPage } from "../components/quran-page";
 import { databaseService } from "../services/sqlite-service";
 import { QuranView } from "../components/quran";
 import { colors } from "../theme";
+import { useMushafStore } from "../store/mushaf-store";
 
 const { height, width } = Dimensions.get("window");
 
@@ -19,8 +20,9 @@ type ViewableItemsChangedInfo = {
 };
 
 export function MushafScreen() {
-  const [currentChapter, setCurrentChapter] = useState(1);
-  const [activeVerse, setActiveVerse] = useState<number | null>(null);
+  const currentChapter = useMushafStore((s) => s.currentChapter);
+  const setCurrentChapter = useMushafStore((s) => s.setCurrentChapter);
+  const activeVerse = useMushafStore((s) => s.activeVerse);
   const pages = Array.from({ length: 604 }, (_, i) => i + 1);
 
   async function updateChapter(pageNumber: number) {
@@ -31,9 +33,7 @@ export function MushafScreen() {
       if (chapterNum) {
         const chapter = await databaseService.getChapterByNumber(chapterNum);
         if (chapter) {
-          setCurrentChapter((prev) =>
-            chapter.number !== prev ? chapter.number : prev,
-          );
+          setCurrentChapter(chapter.number);
         }
       }
     } catch (error) {
@@ -86,10 +86,7 @@ export function MushafScreen() {
         windowSize={3}
       />
       <View style={{ height: 60 }}>
-        {/* <AudioPlayerBar
-          chapterNumber={currentChapter}
-          onVerseChange={(verse) => setActiveVerse(verse)}
-        /> */}
+        {/* <AudioPlayerBar /> */}
       </View>
     </View>
   );

--- a/src/store/mushaf-store.ts
+++ b/src/store/mushaf-store.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+type MushafState = {
+  // Reading state
+  currentChapter: number;
+  activeVerse: number | null;
+  currentPage: number;
+
+  // Playback state
+  isPlaying: boolean;
+
+  // Actions
+  setCurrentChapter: (chapter: number) => void;
+  setActiveVerse: (verse: number | null) => void;
+  setCurrentPage: (page: number) => void;
+  setIsPlaying: (playing: boolean) => void;
+};
+
+export const useMushafStore = create<MushafState>((set) => ({
+  // Initial state
+  currentChapter: 1,
+  activeVerse: null,
+  currentPage: 1,
+  isPlaying: false,
+
+  // Actions
+  setCurrentChapter: (chapter) =>
+    set((state) =>
+      state.currentChapter !== chapter ? { currentChapter: chapter } : state,
+    ),
+  setActiveVerse: (verse) => set({ activeVerse: verse }),
+  setCurrentPage: (page) => set({ currentPage: page }),
+  setIsPlaying: (playing) => set({ isPlaying: playing }),
+}));


### PR DESCRIPTION
## Summary
- Add Zustand for lightweight centralized state management
- New `mushaf-store.ts` with reading state (currentChapter, activeVerse, currentPage) and playback state (isPlaying)
- Refactor `MushafScreen` to use store instead of local `useState`
- Refactor `AudioPlayerBar` to read/write from store instead of props

## Before vs After
**Before:** Props drilling pattern
```
MushafScreen (useState: currentChapter, activeVerse)
  → QuranPage (props: activeChapter, activeVerse)
  → AudioPlayerBar (props: chapterNumber, onVerseChange callback)
```

**After:** Centralized store
```
useMushafStore (Zustand)
  ← MushafScreen reads/writes currentChapter
  ← AudioPlayerBar reads currentChapter, writes activeVerse
  ← QuranPage reads activeVerse (via props, same as before)
```

## Test plan
- [ ] Verify page scrolling still updates current chapter
- [ ] Verify verse highlighting works when AudioPlayerBar is enabled
- [ ] Verify store state persists within the session
- [ ] Run `npx expo start` and verify no runtime errors

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)