### PR TITLE
feat: add jump-to-page input in header navigation

### DIFF
--- a/src/components/PageJumpHeader.tsx
+++ b/src/components/PageJumpHeader.tsx
@@ -1,0 +1,147 @@
+import React, { useState, useRef } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Keyboard,
+} from "react-native";
+import { toArabicDigits } from "../utils/toArabicDigits";
+
+const MIN_PAGE = 1;
+const MAX_PAGE = 604;
+
+interface Props {
+  currentPage: number;
+  onJumpToPage: (page: number) => void;
+}
+
+export const PageJumpHeader: React.FC<Props> = ({
+  currentPage,
+  onJumpToPage,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<TextInput>(null);
+
+  const handlePageDisplay = () => {
+    setInputValue("");
+    setEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 100);
+  };
+
+  const handleSubmit = () => {
+    const pageNum = parseInt(inputValue, 10);
+    if (
+      !Number.isNaN(pageNum) &&
+      pageNum >= MIN_PAGE &&
+      pageNum <= MAX_PAGE
+    ) {
+      onJumpToPage(pageNum);
+    }
+    setEditing(false);
+    setInputValue("");
+    Keyboard.dismiss();
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+    setInputValue("");
+    Keyboard.dismiss();
+  };
+
+  return (
+    <View style={styles.container}>
+      {editing ? (
+        <View style={styles.editRow}>
+          <TouchableOpacity onPress={handleCancel} style={styles.cancelButton}>
+            <Text style={styles.cancelText}>✕</Text>
+          </TouchableOpacity>
+          <TextInput
+            ref={inputRef}
+            style={styles.input}
+            value={inputValue}
+            onChangeText={setInputValue}
+            onSubmitEditing={handleSubmit}
+            keyboardType="number-pad"
+            placeholder={`١ - ${toArabicDigits(MAX_PAGE)}`}
+            placeholderTextColor="#999"
+            maxLength={3}
+            returnKeyType="go"
+            selectTextOnFocus
+          />
+          <TouchableOpacity onPress={handleSubmit} style={styles.goButton}>
+            <Text style={styles.goText}>انتقال</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <TouchableOpacity
+          onPress={handlePageDisplay}
+          style={styles.pageDisplay}
+        >
+          <Text style={styles.pageText}>
+            صفحة {toArabicDigits(currentPage)}
+          </Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: 44,
+    backgroundColor: "#FFF8E1",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#D7CCC8",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 12,
+  },
+  pageDisplay: {
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+  },
+  pageText: {
+    fontSize: 16,
+    color: "#5D4037",
+    fontWeight: "600",
+  },
+  editRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  input: {
+    height: 32,
+    width: 80,
+    borderWidth: 1,
+    borderColor: "#8B4513",
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    textAlign: "center",
+    fontSize: 16,
+    color: "#333",
+    backgroundColor: "#FFF",
+  },
+  goButton: {
+    backgroundColor: "#1B5E20",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  goText: {
+    color: "#FFF",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  cancelButton: {
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  cancelText: {
+    fontSize: 16,
+    color: "#999",
+  },
+});

--- a/src/screens/MushafScreen.tsx
+++ b/src/screens/MushafScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useCallback } from "react";
 import {
   Dimensions,
   FlatList,
@@ -6,11 +6,14 @@ import {
   View,
   ViewToken,
 } from "react-native";
-import { AudioPlayerBar } from "../components/AudioPlayerBar";
 import { QuranPage } from "../components/QuranPage";
+import { PageJumpHeader } from "../components/PageJumpHeader";
 import { databaseService } from "../services/SQLiteService";
 
 const { height, width } = Dimensions.get("window");
+
+const HEADER_HEIGHT = 44;
+const BOTTOM_BAR_HEIGHT = 60;
 
 type ViewableItemsChangedInfo = {
   viewableItems: ViewToken[];
@@ -18,7 +21,9 @@ type ViewableItemsChangedInfo = {
 
 export function MushafScreen() {
   const [currentChapter, setCurrentChapter] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
   const [activeVerse, setActiveVerse] = useState<number | null>(null);
+  const flatListRef = useRef<FlatList>(null);
   const pages = Array.from({ length: 604 }, (_, i) => i + 1);
 
   async function updateChapter(pageNumber: number) {
@@ -48,14 +53,33 @@ export function MushafScreen() {
           : Number.parseInt(first?.key ?? "", 10);
 
       if (Number.isFinite(pageNum)) {
+        setCurrentPage(pageNum);
         void updateChapter(pageNum);
       }
     },
   ).current;
 
+  const handleJumpToPage = useCallback(
+    (page: number) => {
+      if (page < 1 || page > 604) return;
+      // FlatList is inverted, so index 0 = page 1 (rightmost).
+      // pages array is [1,2,...,604], so index = page - 1.
+      const index = page - 1;
+      flatListRef.current?.scrollToIndex({ index, animated: false });
+    },
+    [],
+  );
+
+  const pageHeight = height - HEADER_HEIGHT - BOTTOM_BAR_HEIGHT;
+
   return (
     <View style={styles.container}>
+      <PageJumpHeader
+        currentPage={currentPage}
+        onJumpToPage={handleJumpToPage}
+      />
       <FlatList
+        ref={flatListRef}
         data={pages}
         getItemLayout={(_, index) => ({
           index,
@@ -71,7 +95,7 @@ export function MushafScreen() {
         pagingEnabled
         removeClippedSubviews
         renderItem={({ item }) => (
-          <View style={{ height: height - 60, width }}>
+          <View style={{ height: pageHeight, width }}>
             <QuranPage
               activeChapter={currentChapter}
               activeVerse={activeVerse}
@@ -83,7 +107,7 @@ export function MushafScreen() {
         viewabilityConfig={{ itemVisiblePercentThreshold: 50 }}
         windowSize={3}
       />
-      <View style={{ height: 60 }}>
+      <View style={{ height: BOTTOM_BAR_HEIGHT }}>
         {/* <AudioPlayerBar
           chapterNumber={currentChapter}
           onVerseChange={(verse) => setActiveVerse(verse)}


### PR DESCRIPTION
## Summary
- Adds `PageJumpHeader` component displaying current page number in Arabic digits (صفحة ٤٢)
- Tapping the page number reveals a numeric input field (1-604) with "انتقال" (Go) button
- Navigates instantly to the target page via `FlatList.scrollToIndex`
- Tracks current page via `onViewableItemsChanged` callback

## Changes
- **New**: `src/components/PageJumpHeader.tsx` — self-contained header with display/edit modes
- **Modified**: `src/screens/MushafScreen.tsx` — added `flatListRef`, `currentPage` state, header integration

## Implementation Details
- Input validation: accepts only integers 1-604, silently ignores invalid input
- Uses existing `toArabicDigits` utility for consistent Arabic numeral display
- Compact 44px header preserves mushaf reading space
- Matches existing color scheme (`#FFF8E1` background, `#1B5E20` accent, `#5D4037` text)

## Test plan
- [ ] Tap page number → input field appears with keyboard
- [ ] Enter valid page (e.g., 300) → navigates to page 300
- [ ] Enter invalid page (e.g., 0, 700, abc) → stays on current page
- [ ] Cancel button (✕) dismisses input without navigation
- [ ] Page number updates when swiping between pages
- [ ] Keyboard "Go" button triggers navigation

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)