### PR TITLE
feat: add reading progress tracking with persistence

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+interface Props {
+  percent: number;
+  currentPage: number;
+  totalPages: number;
+}
+
+export function ProgressBar({ percent, currentPage, totalPages }: Props) {
+  const clampedPercent = Math.max(0, Math.min(100, percent));
+  return (
+    <View style={styles.container}>
+      <View style={styles.track}>
+        <View style={[styles.fill, { width: `${clampedPercent}%` }]} />
+      </View>
+      <Text style={styles.label}>
+        {`${currentPage} / ${totalPages} · ${clampedPercent}%`}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    gap: 8,
+  },
+  track: {
+    flex: 1,
+    height: 4,
+    backgroundColor: "#D7CCC8",
+    borderRadius: 2,
+    overflow: "hidden",
+  },
+  fill: {
+    height: "100%",
+    backgroundColor: "#8B4513",
+    borderRadius: 2,
+  },
+  label: {
+    fontSize: 11,
+    color: "#5D4037",
+    minWidth: 80,
+    textAlign: "right",
+  },
+});

--- a/src/hooks/useReadingProgress.ts
+++ b/src/hooks/useReadingProgress.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { databaseService } from "../services/SQLiteService";
+
+export const TOTAL_PAGES = 604;
+const SAVE_DEBOUNCE_MS = 1000;
+
+export function useReadingProgress() {
+  const [lastReadPage, setLastReadPage] = useState<number | null>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingPageRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    databaseService
+      .getLastReadPage()
+      .then((page) => {
+        setLastReadPage(page);
+      })
+      .catch(() => {
+        setLastReadPage(1);
+      });
+
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+      }
+      if (pendingPageRef.current !== null) {
+        databaseService
+          .saveLastReadPage(pendingPageRef.current)
+          .catch(() => {});
+      }
+    };
+  }, []);
+
+  const saveProgress = useCallback((page: number) => {
+    pendingPageRef.current = page;
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+    }
+    saveTimerRef.current = setTimeout(() => {
+      databaseService.saveLastReadPage(page).catch(() => {});
+      pendingPageRef.current = null;
+    }, SAVE_DEBOUNCE_MS);
+  }, []);
+
+  const progressPercent =
+    lastReadPage !== null
+      ? Math.max(1, Math.round((lastReadPage / TOTAL_PAGES) * 100))
+      : 0;
+
+  return { lastReadPage, saveProgress, progressPercent, TOTAL_PAGES };
+}

--- a/src/screens/MushafScreen.tsx
+++ b/src/screens/MushafScreen.tsx
@@ -1,13 +1,15 @@
 import React, { useRef, useState } from "react";
 import {
+  ActivityIndicator,
   Dimensions,
   FlatList,
   StyleSheet,
   View,
   ViewToken,
 } from "react-native";
-import { AudioPlayerBar } from "../components/AudioPlayerBar";
 import { QuranPage } from "../components/QuranPage";
+import { ProgressBar } from "../components/ProgressBar";
+import { useReadingProgress, TOTAL_PAGES } from "../hooks/useReadingProgress";
 import { databaseService } from "../services/SQLiteService";
 
 const { height, width } = Dimensions.get("window");
@@ -19,7 +21,10 @@ type ViewableItemsChangedInfo = {
 export function MushafScreen() {
   const [currentChapter, setCurrentChapter] = useState(1);
   const [activeVerse, setActiveVerse] = useState<number | null>(null);
-  const pages = Array.from({ length: 604 }, (_, i) => i + 1);
+  const { lastReadPage, saveProgress, progressPercent } = useReadingProgress();
+  const [currentPage, setCurrentPage] = useState<number | null>(null);
+  const flatListRef = useRef<FlatList<number>>(null);
+  const pages = Array.from({ length: TOTAL_PAGES }, (_, i) => i + 1);
 
   async function updateChapter(pageNumber: number) {
     try {
@@ -35,7 +40,7 @@ export function MushafScreen() {
         }
       }
     } catch (error) {
-      console.log("Error getting chapter", error);
+      console.error("Error getting chapter", error);
     }
   }
 
@@ -48,14 +53,25 @@ export function MushafScreen() {
           : Number.parseInt(first?.key ?? "", 10);
 
       if (Number.isFinite(pageNum)) {
+        setCurrentPage(pageNum);
+        saveProgress(pageNum);
         void updateChapter(pageNum);
       }
     },
   ).current;
 
+  if (lastReadPage === null) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <ActivityIndicator size="large" color="#8B4513" />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <FlatList
+        ref={flatListRef}
         data={pages}
         getItemLayout={(_, index) => ({
           index,
@@ -64,6 +80,7 @@ export function MushafScreen() {
         })}
         horizontal
         initialNumToRender={1}
+        initialScrollIndex={lastReadPage - 1}
         inverted
         keyExtractor={(item) => item.toString()}
         maxToRenderPerBatch={2}
@@ -84,10 +101,11 @@ export function MushafScreen() {
         windowSize={3}
       />
       <View style={{ height: 60 }}>
-        {/* <AudioPlayerBar
-          chapterNumber={currentChapter}
-          onVerseChange={(verse) => setActiveVerse(verse)}
-        /> */}
+        <ProgressBar
+          percent={progressPercent}
+          currentPage={currentPage ?? lastReadPage ?? 1}
+          totalPages={TOTAL_PAGES}
+        />
       </View>
     </View>
   );
@@ -97,5 +115,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#FFF8E1",
+  },
+  center: {
+    alignItems: "center",
+    justifyContent: "center",
   },
 });

--- a/src/services/SQLiteService.ts
+++ b/src/services/SQLiteService.ts
@@ -127,6 +127,7 @@ class DatabaseService {
         );
 
         if (chapterCount && chapterCount.count > 0) {
+          await this.ensureUserProgressTable(existingDb);
           return existingDb;
         }
 
@@ -145,15 +146,19 @@ class DatabaseService {
         );
         await FileSystem.copyAsync({ from: asset.localUri, to: dbPath });
 
-        return SQLite.openDatabaseAsync(DB_NAME);
+        const copiedDb = await SQLite.openDatabaseAsync(DB_NAME);
+        await this.ensureUserProgressTable(copiedDb);
+        return copiedDb;
       }
 
       const newDb = await SQLite.openDatabaseAsync(DB_NAME);
       await this.initializeDatabase(newDb);
+      await this.ensureUserProgressTable(newDb);
       return newDb;
     } catch {
       const db = await SQLite.openDatabaseAsync(DB_NAME);
       await this.runMigrations(db);
+      await this.ensureUserProgressTable(db);
       return db;
     }
   }
@@ -518,6 +523,41 @@ class DatabaseService {
       highlights1441,
       highlights1405,
     };
+  }
+
+  async getLastReadPage(): Promise<number> {
+    const db = await this.getDb();
+    try {
+      const row = await db.getFirstAsync<{ last_read_page: number }>(
+        "SELECT last_read_page FROM user_progress WHERE id = 1",
+      );
+      const page = row?.last_read_page ?? 1;
+      return Math.max(1, Math.min(604, page));
+    } catch {
+      return 1;
+    }
+  }
+
+  async saveLastReadPage(page: number): Promise<void> {
+    if (!Number.isFinite(page) || page < 1 || page > 604) return;
+    const db = await this.getDb();
+    try {
+      await db.runAsync(
+        "INSERT INTO user_progress (id, last_read_page) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET last_read_page = excluded.last_read_page",
+        [page],
+      );
+    } catch (err) {
+      if (__DEV__) console.warn("[saveLastReadPage] failed:", err);
+    }
+  }
+
+  private async ensureUserProgressTable(db: SQLiteDb): Promise<void> {
+    await db.execAsync(`
+      CREATE TABLE IF NOT EXISTS user_progress (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        last_read_page INTEGER NOT NULL DEFAULT 1
+      );
+    `);
   }
 
   async getChapterByNumber(chapterNumber: number): Promise<Chapter | null> {


### PR DESCRIPTION
## Summary

- Persists last-read page in SQLite (`user_progress` table) — zero new dependencies
- Restores scroll position on app restart via `initialScrollIndex`
- Shows progress bar with page number and percentage in the bottom bar

Closes #38

## Changes

### `src/services/SQLiteService.ts`
- Added `getLastReadPage()` with range clamping (1–604)
- Added `saveLastReadPage()` with input validation and `__DEV__` logging
- Added `ensureUserProgressTable()` — called in all 4 DB initialization paths (existing DB, copied asset, fresh init, catch fallback)
- Uses `INSERT ... ON CONFLICT DO UPDATE` (upsert) for safe single-row persistence

### `src/hooks/useReadingProgress.ts` (NEW)
- Custom hook that loads saved page on mount and exposes debounced save (1s)
- Tracks pending page in a ref and flushes on unmount to prevent data loss
- Exports `TOTAL_PAGES` constant (604) as single source of truth
- `progressPercent` uses `Math.max(1, ...)` so page 1 shows 1% not 0%

### `src/components/ProgressBar.tsx` (NEW)
- Thin progress bar (4px track) with page count and percentage label
- Clamps percent to 0–100 range defensively
- Matches existing brown (`#8B4513`) color scheme

### `src/screens/MushafScreen.tsx`
- Uses `initialScrollIndex={lastReadPage - 1}` for crash-free scroll restore (requires `getItemLayout`, already present)
- Shows loading spinner while DB loads to avoid rendering FlatList before index is known
- Removed dead `AudioPlayerBar` import
- Uses `TOTAL_PAGES` constant instead of magic `604`

## Assembly Line Audit

- ✅ Step 1: Planner agent produced 4-phase plan (SQLite persistence, hook, component, wiring)
- ✅ Step 2: Read all relevant source files (SQLiteService, MushafScreen, hooks dir)
- ✅ Step 3: TDD adapted (no test framework in project)
- ✅ Step 4: Implemented minimal code
- ✅ Step 5: HARD GATE #1 — `tsc --noEmit` exit 0
- ✅ Step 6: Code reviewer found 1 CRITICAL, 5 HIGH, 4 MEDIUM issues
- ✅ Step 7: Fixed: scrollToIndex crash → initialScrollIndex, timer cleanup, ensureUserProgressTable simplified, console.log → console.error, dead import removed
- ✅ Step 8: HARD GATE #2 — `tsc --noEmit` exit 0
- ✅ Step 9: Grumpy tester found 3 CRITICAL, 2 HIGH, 5 MEDIUM issues
- ✅ Step 10: Fixed: range clamping on getLastReadPage, flush-on-unmount, TOTAL_PAGES constant, ProgressBar clamping, Math.max(1,...) for 0% edge case
- ✅ Step 11: HARD GATE #3 — `tsc --noEmit` exit 0
- ✅ Step 12: Verification with grep evidence — all items confirmed
- ✅ Step 13: Commit, push, PR

## Test Plan

- [ ] Fresh install → app opens at page 1, progress bar shows `1 / 604 · 1%`
- [ ] Scroll to page 300 → progress bar updates to `300 / 604 · 50%`
- [ ] Kill and reopen app → resumes at page 300
- [ ] Scroll to page 604 → shows `604 / 604 · 100%`
- [ ] Scroll to page 1 → shows `1 / 604 · 1%`
- [ ] Quick scroll through multiple pages → debounce prevents DB hammering
- [ ] Close app within 1s of scrolling → flush saves the pending page (no data loss)
- [ ] Loading spinner shown briefly while DB loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading progress is now automatically tracked and persisted, allowing you to resume from your last read page
  * A visual progress bar displays your current position, showing both page numbers and completion percentage
  * Reading position updates automatically as you navigate through content without requiring manual saves

<!-- end of auto-generated comment: release notes by coderabbit.ai -->