### PR TITLE
feat: add visual loading state during database initialization

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useFonts } from "expo-font";
 
 import { MushafScreen } from "./src/screens/MushafScreen";
+import { DbLoadingScreen } from "./src/components/DbLoadingScreen";
+import { useDbInit } from "./src/hooks/useDbInit";
 
 SplashScreen.preventAutoHideAsync().catch(() => undefined);
 
@@ -15,12 +17,15 @@ export default function App() {
   const [fontsLoaded, fontError] = useFonts({
     uthmanTn1Bold: require("./assets/fonts/UthmanTN1B-Ver20.ttf"),
   });
+  const { loading: dbLoading, error: dbError, retry: retryDb } = useDbInit();
 
   useEffect(() => {
-    if (fontsLoaded || fontError) {
+    if (fontError) {
+      void SplashScreen.hideAsync();
+    } else if (fontsLoaded && !dbLoading) {
       void SplashScreen.hideAsync();
     }
-  }, [fontsLoaded, fontError]);
+  }, [fontsLoaded, fontError, dbLoading]);
 
   if (fontError) {
     throw fontError;
@@ -31,6 +36,15 @@ export default function App() {
       <View style={styles.loader}>
         <ActivityIndicator size="large" />
       </View>
+    );
+  }
+
+  if (dbLoading || dbError) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <StatusBar style="dark" />
+        <DbLoadingScreen error={dbError} onRetry={retryDb} />
+      </SafeAreaView>
     );
   }
 
@@ -45,7 +59,7 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
+    backgroundColor: "#FFF8E1",
   },
   loader: {
     flex: 1,

--- a/src/components/DbLoadingScreen.tsx
+++ b/src/components/DbLoadingScreen.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+interface Props {
+  error: string | null;
+  onRetry: () => void;
+}
+
+export function DbLoadingScreen({ error, onRetry }: Props) {
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.errorText}>{error}</Text>
+        <TouchableOpacity style={styles.retryButton} onPress={onRetry}>
+          <Text style={styles.retryText}>إعادة المحاولة</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color="#8B4513" />
+      <Text style={styles.loadingText}>جارٍ تهيئة قاعدة البيانات...</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#FFF8E1",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  loadingText: {
+    marginTop: 16,
+    fontSize: 16,
+    color: "#5D4037",
+    textAlign: "center",
+  },
+  errorText: {
+    color: "#D32F2F",
+    fontSize: 16,
+    textAlign: "center",
+    marginBottom: 15,
+  },
+  retryButton: {
+    backgroundColor: "#8B4513",
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: "white",
+    fontWeight: "bold",
+  },
+});

--- a/src/hooks/useDbInit.ts
+++ b/src/hooks/useDbInit.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { databaseService } from "../services/SQLiteService";
+
+type DbInitState = {
+  loading: boolean;
+  error: string | null;
+  retry: () => void;
+};
+
+function toUserMessage(err: unknown): string {
+  if (!(err instanceof Error)) return "فشل في تهيئة قاعدة البيانات";
+  const msg = err.message.toLowerCase();
+  if (msg.includes("network") || msg.includes("fetch"))
+    return "تعذر تحميل قاعدة البيانات. تحقق من الاتصال بالإنترنت";
+  if (msg.includes("enoent") || msg.includes("no such file"))
+    return "خطأ في نظام الملفات. حاول إعادة تثبيت التطبيق";
+  if (msg.includes("enospc") || msg.includes("disk") || msg.includes("space"))
+    return "مساحة التخزين غير كافية";
+  return "فشل في تهيئة قاعدة البيانات";
+}
+
+export function useDbInit(): DbInitState {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  const runInit = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    databaseService
+      .initialize()
+      .then(() => {
+        if (mountedRef.current) setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (!mountedRef.current) return;
+        if (
+          err instanceof Error &&
+          err.message === "DB init cancelled by reset"
+        )
+          return;
+        setError(toUserMessage(err));
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    runInit();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [runInit]);
+
+  const retry = useCallback(() => {
+    databaseService.reset();
+    runInit();
+  }, [runInit]);
+
+  return { loading, error, retry };
+}

--- a/src/services/SQLiteService.ts
+++ b/src/services/SQLiteService.ts
@@ -99,6 +99,20 @@ type SQLiteDb = Awaited<ReturnType<typeof SQLite.openDatabaseAsync>>;
 class DatabaseService {
   private db: SQLiteDb | null = null;
   private initPromise: Promise<SQLiteDb> | null = null;
+  private initGeneration = 0;
+
+  async initialize(): Promise<void> {
+    await this.getDb();
+  }
+
+  reset(): void {
+    this.initGeneration++;
+    if (this.db) {
+      this.db.closeAsync().catch(() => {});
+    }
+    this.db = null;
+    this.initPromise = null;
+  }
 
   async getDb(): Promise<SQLiteDb> {
     if (this.db) {
@@ -109,8 +123,14 @@ class DatabaseService {
       return this.initPromise;
     }
 
+    const generation = this.initGeneration;
     this.initPromise = this.initDatabase();
-    this.db = await this.initPromise;
+    const db = await this.initPromise;
+    if (this.initGeneration !== generation) {
+      db.closeAsync().catch(() => {});
+      throw new Error("DB init cancelled by reset");
+    }
+    this.db = db;
     return this.db;
   }
 
@@ -154,6 +174,15 @@ class DatabaseService {
     } catch {
       const db = await SQLite.openDatabaseAsync(DB_NAME);
       await this.runMigrations(db);
+      const count = await db.getFirstAsync<{ count: number }>(
+        "SELECT COUNT(*) as count FROM chapters",
+      );
+      if (!count || count.count === 0) {
+        await db.closeAsync().catch(() => {});
+        throw new Error(
+          "فشل في تحميل قاعدة البيانات: البيانات غير موجودة",
+        );
+      }
       return db;
     }
   }


### PR DESCRIPTION
## Summary

- Shows a branded loading screen while `quran.db` is copied on first launch
- Displays Arabic error messages with retry button if initialization fails
- Gates `MushafScreen` behind DB readiness — no blank screen

Closes #27

## Changes

### `src/services/SQLiteService.ts`
- Added `initialize(): Promise<void>` — public entry point for eager DB init
- Added `reset()` with generation counter — safely cancels in-flight init on retry, closes stale DB handles
- Generation check in `getDb()` discards results from cancelled initializations
- Catch-fallback path now validates DB has data (`SELECT COUNT(*) FROM chapters`); throws Arabic error if empty instead of silently serving an empty database

### `src/hooks/useDbInit.ts` (NEW)
- Tracks `loading`, `error`, `retry` state for DB initialization
- `mountedRef` guard prevents setState on unmounted component
- Filters out internal "DB init cancelled by reset" errors — not shown to user
- `toUserMessage()` maps technical errors to Arabic user-facing messages:
  - Network errors → "تعذر تحميل قاعدة البيانات. تحقق من الاتصال بالإنترنت"
  - Filesystem errors → "خطأ في نظام الملفات. حاول إعادة تثبيت التطبيق"
  - Disk space errors → "مساحة التخزين غير كافية"
  - Default → "فشل في تهيئة قاعدة البيانات"

### `src/components/DbLoadingScreen.tsx` (NEW)
- Full-screen loading/error component matching app's warm color scheme (`#FFF8E1`)
- Loading: brown `ActivityIndicator` + "جارٍ تهيئة قاعدة البيانات..." text
- Error: red error text + brown "إعادة المحاولة" retry button
- Matches existing `QuranPage.tsx` error styling conventions

### `App.tsx`
- Wired `useDbInit` hook alongside existing `useFonts`
- Splash screen persists until both fonts loaded AND DB ready (prevents flash)
- `fontError` hides splash unconditionally (prevents stuck splash)
- `MushafScreen` only mounts after DB is fully initialized
- Updated container background to `#FFF8E1` for consistency

## Assembly Line Audit

- ✅ Step 1: Planner agent produced 4-phase plan
- ✅ Step 2: Read SQLiteService, App.tsx, MushafScreen, expo-file-system types
- ✅ Step 3: TDD adapted (no test framework)
- ✅ Step 4: Implemented minimal code
- ✅ Step 5: HARD GATE #1 — `tsc --noEmit` exit 0
- ✅ Step 6: Code reviewer found 1 CRITICAL, 3 HIGH, 3 MEDIUM issues
- ✅ Step 7: Fixed: generation counter, unmount guard, splash timing, DB close on reset
- ✅ Step 8: HARD GATE #2 — `tsc --noEmit` exit 0
- ✅ Step 9: Grumpy tester found 3 CRITICAL, 2 HIGH, 4 MEDIUM issues
- ✅ Step 10: Fixed: cancel error filtering, empty DB validation, Arabic error mapping, splash stuck fix
- ✅ Step 11: HARD GATE #3 — `tsc --noEmit` exit 0
- ✅ Step 12: Verification with grep evidence
- ✅ Step 13: Commit, push, PR

## Test Plan

- [ ] First launch (no DB on device) → loading screen shown with spinner + Arabic text
- [ ] Subsequent launch (DB exists) → loading screen appears briefly then MushafScreen loads
- [ ] Simulate init failure → error screen with Arabic message and retry button
- [ ] Tap retry → loading screen, then successful load
- [ ] Rapid retry taps → no crash, generation counter prevents race conditions
- [ ] DB copy succeeds but DB is empty → error thrown, user sees error screen
- [ ] Font loading fails → splash hides, font error boundary catches