### PR TITLE
feat: add safe area inset handling to MushafScreen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useFonts } from "expo-font";
 
 import { MushafScreen } from "./src/screens/MushafScreen";
@@ -28,17 +28,21 @@ export default function App() {
 
   if (!fontsLoaded) {
     return (
-      <View style={styles.loader}>
-        <ActivityIndicator size="large" />
-      </View>
+      <SafeAreaProvider>
+        <View style={styles.loader}>
+          <ActivityIndicator size="large" />
+        </View>
+      </SafeAreaProvider>
     );
   }
 
   return (
-    <SafeAreaView style={styles.container}>
-      <StatusBar style="dark" />
-      <MushafScreen />
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <View style={styles.container}>
+        <StatusBar style="dark" />
+        <MushafScreen />
+      </View>
+    </SafeAreaProvider>
   );
 }
 

--- a/src/screens/MushafScreen.tsx
+++ b/src/screens/MushafScreen.tsx
@@ -1,25 +1,28 @@
-import React, { useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import {
-  Dimensions,
   FlatList,
   StyleSheet,
+  useWindowDimensions,
   View,
   ViewToken,
 } from "react-native";
-import { AudioPlayerBar } from "../components/AudioPlayerBar";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { QuranPage } from "../components/QuranPage";
 import { databaseService } from "../services/SQLiteService";
 
-const { height, width } = Dimensions.get("window");
+const BOTTOM_BAR_HEIGHT = 60;
 
 type ViewableItemsChangedInfo = {
   viewableItems: ViewToken[];
 };
 
 export function MushafScreen() {
+  const { height, width } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const pageHeight = Math.max(0, height - insets.top - insets.bottom - BOTTOM_BAR_HEIGHT);
   const [currentChapter, setCurrentChapter] = useState(1);
   const [activeVerse, setActiveVerse] = useState<number | null>(null);
-  const pages = Array.from({ length: 604 }, (_, i) => i + 1);
+  const pages = useMemo(() => Array.from({ length: 604 }, (_, i) => i + 1), []);
 
   async function updateChapter(pageNumber: number) {
     try {
@@ -35,7 +38,7 @@ export function MushafScreen() {
         }
       }
     } catch (error) {
-      console.log("Error getting chapter", error);
+      console.error("Error getting chapter", error);
     }
   }
 
@@ -53,15 +56,25 @@ export function MushafScreen() {
     },
   ).current;
 
+  const getItemLayout = useCallback(
+    (_: ArrayLike<number> | null | undefined, index: number) => ({
+      index,
+      length: width,
+      offset: width * index,
+    }),
+    [width],
+  );
+
   return (
-    <View style={styles.container}>
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, paddingBottom: insets.bottom },
+      ]}
+    >
       <FlatList
         data={pages}
-        getItemLayout={(_, index) => ({
-          index,
-          length: width,
-          offset: width * index,
-        })}
+        getItemLayout={getItemLayout}
         horizontal
         initialNumToRender={1}
         inverted
@@ -71,7 +84,7 @@ export function MushafScreen() {
         pagingEnabled
         removeClippedSubviews
         renderItem={({ item }) => (
-          <View style={{ height: height - 60, width }}>
+          <View style={{ height: pageHeight, width }}>
             <QuranPage
               activeChapter={currentChapter}
               activeVerse={activeVerse}
@@ -83,7 +96,7 @@ export function MushafScreen() {
         viewabilityConfig={{ itemVisiblePercentThreshold: 50 }}
         windowSize={3}
       />
-      <View style={{ height: 60 }}>
+      <View style={{ height: BOTTOM_BAR_HEIGHT }}>
         {/* <AudioPlayerBar
           chapterNumber={currentChapter}
           onVerseChange={(verse) => setActiveVerse(verse)}


### PR DESCRIPTION
## Summary

- Replace static `Dimensions.get("window")` with `useWindowDimensions()` + `useSafeAreaInsets()` hooks in MushafScreen
- Wrap App.tsx with `SafeAreaProvider` (replacing `SafeAreaView` to avoid double-subtraction of insets)
- Apply `paddingTop: insets.top` / `paddingBottom: insets.bottom` to MushafScreen container
- Compute `pageHeight` from dynamic dimensions minus insets minus bottom bar
- Memoize `pages` array with `useMemo` to prevent FlatList churn on re-renders
- Memoize `getItemLayout` with `useCallback` to preserve FlatList layout cache
- Guard `pageHeight` with `Math.max(0, ...)` against negative values on small form factors
- Extract `BOTTOM_BAR_HEIGHT = 60` constant (replacing magic number)
- Remove dead `AudioPlayerBar` import
- Fix `console.log` → `console.error` for error logging

## Files changed

| File | Change |
|------|--------|
| `App.tsx` | `SafeAreaView` → `SafeAreaProvider` + plain `View` |
| `src/screens/MushafScreen.tsx` | Reactive hooks, inset padding, memoization, cleanup |

## Why SafeAreaProvider instead of SafeAreaView?

`SafeAreaView` automatically applies inset padding to its children. If `MushafScreen` also uses `useSafeAreaInsets()` to subtract insets from `useWindowDimensions().height`, the insets would be subtracted **twice** — once by SafeAreaView's padding and once in the height calculation. Using `SafeAreaProvider` (which only provides context without applying padding) plus explicit inset handling in MushafScreen avoids this double-subtraction.

## Test plan

- [ ] Verify content does not overlap status bar or home indicator on notched devices (iPhone X+, modern Android)
- [ ] Verify Quran pages fill available space correctly (no gap, no clipping)
- [ ] Verify horizontal paging still snaps correctly
- [ ] Verify bottom bar remains visible and doesn't overlap content
- [ ] Test on a device with zero insets (older phones / simulator) — should render identically to before
- [ ] Test on split-screen / small window (Android) — should not crash or render negative-height views

Closes #33