### PR TITLE
fix: center ayah marker text using flexbox (iOS + Android)

### DIFF
--- a/src/components/VerseFasel.tsx
+++ b/src/components/VerseFasel.tsx
@@ -7,7 +7,6 @@ const BALANCE = 3.69;
 const BASE_WIDTH = 21 * BALANCE;
 const BASE_HEIGHT = 27 * BALANCE;
 const BASE_FONT_SIZE = 14 * BALANCE;
-const BASE_PADDING = 2 * BALANCE;
 
 type Props = {
   number: number;
@@ -18,44 +17,38 @@ export function VerseFasel({ number, scale }: Props) {
   const width = BASE_WIDTH * scale;
   const height = BASE_HEIGHT * scale;
   const fontSize = BASE_FONT_SIZE * scale;
-  const paddingHorizontal = BASE_PADDING * scale;
 
   return (
     <View style={[styles.container, { width, height }]}>
       <Fasel width={width} height={height} />
-      <Text
-        adjustsFontSizeToFit
-        minimumFontScale={0.8}
-        style={[
-          styles.text,
-          {
-            fontSize,
-            paddingHorizontal,
-            transform: [
-              { translateX: -1 * scale },
-              { translateY: 1 * scale },
-            ],
-          },
-        ]}
-      >
-        {toArabicDigits(number)}
-      </Text>
+      <View style={styles.textWrapper}>
+        <Text
+          adjustsFontSizeToFit
+          minimumFontScale={0.8}
+          numberOfLines={1}
+          style={[styles.text, { fontSize }]}
+        >
+          {toArabicDigits(number)}
+        </Text>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    position: "relative",
-  },
-  text: {
+  container: {},
+  textWrapper: {
     position: "absolute",
     left: 0,
     right: 0,
     top: 0,
     bottom: 0,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  text: {
+    alignSelf: "stretch",
     textAlign: "center",
-    textAlignVertical: "center",
     fontFamily: "uthman_tn1_bold",
     color: "#000",
   },


### PR DESCRIPTION
## Summary

- Replace Android-only `textAlignVertical: "center"` with cross-platform flexbox centering wrapper
- Remove unreliable `transform: [{ translateX: -1 * scale }, { translateY: 1 * scale }]` pixel nudge
- Remove `paddingHorizontal` workaround
- Add `alignSelf: "stretch"` + `textAlign: "center"` for reliable horizontal centering
- Add `numberOfLines={1}` to pair with `adjustsFontSizeToFit`

## Root cause

The `textAlignVertical` CSS property is **Android-only** in React Native — iOS silently ignores it. The previous implementation relied on this plus a manual pixel offset (`translateX: -1, translateY: 1`) to center the ayah number text inside the SVG marker. This approach produced different results on iOS vs Android and varied across device sizes.

## Fix

Wrap the `<Text>` in an absolute-positioned `<View>` with `justifyContent: "center"` and `alignItems: "center"`. This is the standard React Native cross-platform centering pattern. The SVG background renders first (normal flow), and the text wrapper overlays it via absolute positioning filling the same container bounds.

## Files changed

| File | Change |
|------|--------|
| `src/components/VerseFasel.tsx` | Flexbox centering wrapper, removed platform-specific hacks |

## Test plan

- [ ] Verify ayah numbers are visually centered in the marker on iOS (device or simulator)
- [ ] Verify ayah numbers remain centered on Android — no regression
- [ ] Test single-digit (١), double-digit (١٥), and triple-digit (٢٨٦) verse numbers
- [ ] Test on small screens (iPhone SE) and large screens (iPhone Pro Max)
- [ ] `npx tsc --noEmit` passes cleanly

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Enhanced text rendering and layout in verse display with improved centering and single-line text constraint.
  * Simplified styling structure for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->