### PR TITLE
feat: add Arabic full-text search with FTS5

### DIFF
--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -1,0 +1,188 @@
+import React, { useCallback, useEffect } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useVerseSearch } from "../hooks/useVerseSearch";
+import { SearchResult } from "../services/SQLiteService";
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onSelectResult: (pageNumber: number) => void;
+}
+
+export function SearchModal({ visible, onClose, onSelectResult }: Props) {
+  const insets = useSafeAreaInsets();
+  const { query, setQuery, results, loading, error } = useVerseSearch();
+
+  useEffect(() => {
+    if (!visible) {
+      setQuery("");
+    }
+  }, [visible, setQuery]);
+
+  const handleSelect = useCallback(
+    (item: SearchResult) => {
+      const page = item.page1441_id;
+      if (!page || page < 1 || page > 604) {
+        Alert.alert("تنبيه", "لا يمكن الانتقال إلى هذه الآية");
+        return;
+      }
+      onSelectResult(page);
+      onClose();
+    },
+    [onSelectResult, onClose],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: SearchResult }) => (
+      <TouchableOpacity
+        style={styles.resultRow}
+        onPress={() => handleSelect(item)}
+        accessibilityLabel={`${item.chapterArabicTitle} الآية ${item.number}`}
+        accessibilityRole="button"
+      >
+        <Text style={styles.resultMeta}>
+          {item.chapterArabicTitle} - الآية {item.number}
+        </Text>
+        <Text style={styles.resultText} numberOfLines={2}>
+          {item.searchableText}
+        </Text>
+      </TouchableOpacity>
+    ),
+    [handleSelect],
+  );
+
+  const trimmed = query.trim();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <View style={[styles.header, { paddingTop: Math.max(insets.top, 12) + 12 }]}>
+          <TouchableOpacity
+            onPress={onClose}
+            style={styles.closeButton}
+            accessibilityLabel="إغلاق البحث"
+            accessibilityRole="button"
+          >
+            <Text style={styles.closeText}>✕</Text>
+          </TouchableOpacity>
+          <TextInput
+            style={styles.input}
+            placeholder="ابحث في القرآن الكريم..."
+            placeholderTextColor="#ccc"
+            value={query}
+            onChangeText={setQuery}
+            autoFocus
+            textAlign="right"
+            returnKeyType="search"
+            accessibilityLabel="البحث في القرآن الكريم"
+          />
+        </View>
+
+        {loading && (
+          <ActivityIndicator
+            style={styles.center}
+            size="large"
+            color="#1B5E20"
+          />
+        )}
+        {error && <Text style={styles.errorText}>{error}</Text>}
+        {!loading && !error && trimmed !== "" && results.length === 0 && (
+          <Text style={styles.emptyText}>لا توجد نتائج</Text>
+        )}
+        {!loading && results.length > 0 && (
+          <FlatList
+            data={results}
+            keyExtractor={(item) => item.verseID.toString()}
+            renderItem={renderItem}
+            keyboardShouldPersistTaps="handled"
+          />
+        )}
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#FFF8E1",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#1B5E20",
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+  },
+  closeButton: {
+    padding: 8,
+    marginRight: 8,
+  },
+  closeText: {
+    fontSize: 20,
+    color: "#fff",
+    fontWeight: "bold",
+  },
+  input: {
+    flex: 1,
+    color: "#fff",
+    fontSize: 18,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: "rgba(255,255,255,0.15)",
+    borderRadius: 8,
+  },
+  center: {
+    marginTop: 40,
+  },
+  errorText: {
+    color: "#D32F2F",
+    fontSize: 16,
+    textAlign: "center",
+    marginTop: 40,
+    paddingHorizontal: 20,
+  },
+  emptyText: {
+    color: "#999",
+    fontSize: 16,
+    textAlign: "center",
+    marginTop: 40,
+  },
+  resultRow: {
+    padding: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: "#E0E0E0",
+  },
+  resultMeta: {
+    fontSize: 12,
+    color: "#666",
+    textAlign: "right",
+    marginBottom: 4,
+  },
+  resultText: {
+    fontSize: 16,
+    color: "#1B1B1B",
+    textAlign: "right",
+    lineHeight: 26,
+  },
+});

--- a/src/hooks/useVerseSearch.ts
+++ b/src/hooks/useVerseSearch.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from "react";
+import { databaseService, SearchResult } from "../services/SQLiteService";
+
+const DEBOUNCE_MS = 300;
+
+export function useVerseSearch() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const generationRef = useRef(0);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    const trimmed = query.trim();
+    if (!trimmed) {
+      generationRef.current++;
+      setResults([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    timerRef.current = setTimeout(async () => {
+      const gen = ++generationRef.current;
+      if (!mountedRef.current) return;
+      setLoading(true);
+      setError(null);
+
+      try {
+        const data = await databaseService.searchVerses(trimmed);
+        if (gen !== generationRef.current || !mountedRef.current) return;
+        setResults(data);
+      } catch {
+        if (gen !== generationRef.current || !mountedRef.current) return;
+        setError("حدث خطأ أثناء البحث");
+        setResults([]);
+      } finally {
+        if (gen === generationRef.current && mountedRef.current) {
+          setLoading(false);
+        }
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [query]);
+
+  return { query, setQuery, results, loading, error };
+}

--- a/src/screens/MushafScreen.tsx
+++ b/src/screens/MushafScreen.tsx
@@ -1,13 +1,15 @@
-import React, { useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import {
   Dimensions,
   FlatList,
   StyleSheet,
+  Text,
+  TouchableOpacity,
   View,
   ViewToken,
 } from "react-native";
-import { AudioPlayerBar } from "../components/AudioPlayerBar";
 import { QuranPage } from "../components/QuranPage";
+import { SearchModal } from "../components/SearchModal";
 import { databaseService } from "../services/SQLiteService";
 
 const { height, width } = Dimensions.get("window");
@@ -19,7 +21,14 @@ type ViewableItemsChangedInfo = {
 export function MushafScreen() {
   const [currentChapter, setCurrentChapter] = useState(1);
   const [activeVerse, setActiveVerse] = useState<number | null>(null);
+  const [searchVisible, setSearchVisible] = useState(false);
+  const flatListRef = useRef<FlatList<number>>(null);
   const pages = Array.from({ length: 604 }, (_, i) => i + 1);
+
+  const navigateToPage = useCallback((pageNumber: number) => {
+    const index = pageNumber - 1;
+    flatListRef.current?.scrollToIndex({ index, animated: true });
+  }, []);
 
   async function updateChapter(pageNumber: number) {
     try {
@@ -56,6 +65,7 @@ export function MushafScreen() {
   return (
     <View style={styles.container}>
       <FlatList
+        ref={flatListRef}
         data={pages}
         getItemLayout={(_, index) => ({
           index,
@@ -67,6 +77,11 @@ export function MushafScreen() {
         inverted
         keyExtractor={(item) => item.toString()}
         maxToRenderPerBatch={2}
+        onScrollToIndexFailed={({ index }) => {
+          setTimeout(() => {
+            flatListRef.current?.scrollToIndex({ index, animated: true });
+          }, 500);
+        }}
         onViewableItemsChanged={onViewableItemsChanged}
         pagingEnabled
         removeClippedSubviews
@@ -89,6 +104,20 @@ export function MushafScreen() {
           onVerseChange={(verse) => setActiveVerse(verse)}
         /> */}
       </View>
+      <TouchableOpacity
+        style={styles.searchButton}
+        onPress={() => setSearchVisible(true)}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityLabel="البحث في القرآن"
+        accessibilityRole="button"
+      >
+        <Text style={styles.searchIcon}>&#x1F50D;</Text>
+      </TouchableOpacity>
+      <SearchModal
+        visible={searchVisible}
+        onClose={() => setSearchVisible(false)}
+        onSelectResult={navigateToPage}
+      />
     </View>
   );
 }
@@ -97,5 +126,17 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#FFF8E1",
+  },
+  searchButton: {
+    position: "absolute",
+    top: 12,
+    left: 16,
+    zIndex: 10,
+    backgroundColor: "rgba(255,255,255,0.85)",
+    borderRadius: 20,
+    padding: 8,
+  },
+  searchIcon: {
+    fontSize: 22,
   },
 });

--- a/src/services/SQLiteService.ts
+++ b/src/services/SQLiteService.ts
@@ -80,6 +80,17 @@ export type Page = {
   verses1405: Verse[];
 };
 
+export type SearchResult = {
+  verseID: number;
+  number: number;
+  humanReadableID: string;
+  searchableText: string;
+  chapter_id: number | null;
+  chapterArabicTitle: string;
+  chapterEnglishTitle: string;
+  page1441_id: number | null;
+};
+
 type VerseRow = Omit<
   Verse,
   "marker1441" | "marker1405" | "highlights1441" | "highlights1405"
@@ -111,6 +122,8 @@ class DatabaseService {
 
     this.initPromise = this.initDatabase();
     this.db = await this.initPromise;
+    // Pre-warm FTS index in background after DB is ready
+    this.ensureFtsTable().catch(() => {});
     return this.db;
   }
 
@@ -539,6 +552,67 @@ class DatabaseService {
     );
 
     return chapters;
+  }
+
+  private ftsInitPromise: Promise<void> | null = null;
+
+  private ensureFtsTable(): Promise<void> {
+    if (!this.ftsInitPromise) {
+      this.ftsInitPromise = this.getDb().then((db) => this.buildFtsTable(db));
+    }
+    return this.ftsInitPromise;
+  }
+
+  private async buildFtsTable(db: SQLiteDb): Promise<void> {
+    const exists = await db.getFirstAsync<{ count: number }>(
+      "SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name='verses_fts'",
+    );
+
+    if (exists && exists.count > 0) return;
+
+    await db.execAsync(
+      "CREATE VIRTUAL TABLE IF NOT EXISTS verses_fts " +
+        "USING fts5(verseID UNINDEXED, searchableText, content=verses, content_rowid=verseID)",
+    );
+    await db.execAsync(
+      "INSERT INTO verses_fts(verses_fts) VALUES('rebuild')",
+    );
+  }
+
+  private static stripTashkil(text: string): string {
+    return text.replace(/[\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED]/g, "");
+  }
+
+  async searchVerses(query: string, limit = 30): Promise<SearchResult[]> {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    await this.ensureFtsTable();
+    const db = await this.getDb();
+
+    const stripped = DatabaseService.stripTashkil(trimmed).replace(/"/g, "");
+    if (!stripped) return [];
+    const sanitized = stripped.length > 200 ? stripped.slice(0, 200) : stripped;
+    const ftsQuery = `"${sanitized}"*`;
+
+    return db.getAllAsync<SearchResult>(
+      `SELECT
+         v.verseID,
+         v.number,
+         v.humanReadableID,
+         v.searchableText,
+         v.chapter_id,
+         c.arabicTitle  AS chapterArabicTitle,
+         c.englishTitle AS chapterEnglishTitle,
+         v.page1441_id
+       FROM verses_fts
+       JOIN verses  v ON v.verseID = verses_fts.rowid
+       LEFT JOIN chapters c ON c.identifier = v.chapter_id
+       WHERE verses_fts MATCH ?
+       ORDER BY rank
+       LIMIT ?`,
+      [ftsQuery, limit],
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds full-text search capability using SQLite FTS5 virtual tables
- FTS5 table built lazily from existing `searchableText` column with `content=verses` (no data duplication)
- Pre-warms FTS index in background after database initialization
- Arabic tashkil (diacritics) stripped from user input before searching, matching the diacritics-free `searchableText` column
- Debounced search with generation counter to discard stale/out-of-order results
- Full-screen search modal with RTL layout, safe area insets, accessibility labels

## Changes

| File | What |
|------|------|
| `src/services/SQLiteService.ts` | `SearchResult` type, `stripTashkil()`, `ensureFtsTable()`/`buildFtsTable()`, `searchVerses()` with sanitization + 200-char cap |
| `src/hooks/useVerseSearch.ts` | Debounced search hook with generation counter, mounted guard, loading state inside debounce |
| `src/components/SearchModal.tsx` | Full-screen modal with TextInput, FlatList results, loading/error/empty states, Alert on invalid page |
| `src/screens/MushafScreen.tsx` | Floating search button, `FlatList` ref + `navigateToPage`, `SearchModal` integration |

## Key Design Decisions

- **FTS5 `content=` table** — avoids doubling database size by referencing existing `verses` table
- **Tashkil stripping** — users typing with diacritics (common on Arabic keyboards) get results matching the stripped index
- **Generation counter** — prevents race condition where fast typing produces out-of-order results
- **Pre-warm on init** — FTS rebuild happens in background after DB opens, so first search is fast
- **Query sanitization** — double-quotes stripped, length capped at 200 chars, empty-after-strip returns `[]`
- **`useSafeAreaInsets()`** — replaces hardcoded 52px padding for correct safe area on all iOS devices

## Test plan

- [ ] Open app, tap search icon (magnifying glass, top-left)
- [ ] Type Arabic text (e.g., "بسم الله") — results should appear after debounce
- [ ] Type with tashkil (e.g., "بِسْمِ اللَّهِ") — should return same results
- [ ] Tap a result — modal closes, page navigates to correct Quran page
- [ ] Close modal and reopen — search field should be empty, no stale results
- [ ] Type rapidly — no flickering, only final results displayed
- [ ] Test on iPhone SE + iPhone 14 Pro — header padding adapts to safe area
- [ ] Test with VoiceOver/TalkBack — all interactive elements have Arabic labels

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive verse search functionality with dedicated search modal interface
  * Search results display chapter title, verse number, and full verse text
  * Tap search results to navigate directly to the corresponding verse pages
  * Real-time search with automatic validation, error handling, and empty-state messaging
  * Accessible search input and results with keyboard-aware responsive layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->