### PR TITLE
feat: implement audio recitation with real-time verse highlighting

### DIFF
--- a/src/components/AudioPlayerBar.tsx
+++ b/src/components/AudioPlayerBar.tsx
@@ -1,76 +1,112 @@
-import React, { useEffect, useState } from 'react';
-import { View, Button, StyleSheet, Text } from 'react-native';
-import { useAudioPlayer } from 'expo-audio';
-import { loadTiming } from '../services/AyahTimingService';
+import React, { useEffect } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useRecitationPlayer } from "../hooks/useRecitationPlayer";
 
 interface Props {
   chapterNumber: number;
-  onVerseChange: (verseNumber: number) => void;
+  onVerseChange: (verseNumber: number | null) => void;
 }
 
-export const AudioPlayerBar: React.FC<Props> = ({ chapterNumber, onVerseChange }) => {
-  const paddedChapter = chapterNumber.toString().padStart(3, '0');
-  const url = `https://server6.mp3quran.net/akdr/${paddedChapter}.mp3`;
-  
-  const player = useAudioPlayer(url);
-  const [timing, setTiming] = useState<any>(null);
-  const [isPlaying, setIsPlaying] = useState(false);
+export function AudioPlayerBar({ chapterNumber, onVerseChange }: Props) {
+  const {
+    isPlaying,
+    isLoaded,
+    activeVerse,
+    currentTimeMs,
+    durationMs,
+    progress,
+    hasEnded,
+    toggle,
+  } = useRecitationPlayer(chapterNumber);
 
   useEffect(() => {
-    loadTiming(1).then(data => {
-      if (data) {
-        const chapterData = data.chapters.find((c: any) => c.id === chapterNumber);
-        setTiming(chapterData);
-      }
-    });
-  }, [chapterNumber]);
+    onVerseChange(activeVerse);
+  }, [activeVerse, onVerseChange]);
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      // Check if player is playing. Note: player.playing might be a getter.
-      // We assume player object is stable but its properties change.
-      // However, hooks usually trigger re-render on change if they are stateful.
-      // If useAudioPlayer returns a plain object ref, we need to poll.
-      
-      const playing = player.playing;
-      if (playing !== isPlaying) {
-        setIsPlaying(playing);
-      }
-
-      if (playing && timing) {
-        const timeMs = player.currentTime * 1000;
-        const verse = timing.aya_timing.find((t: any) => timeMs >= t.start_time && timeMs < t.end_time);
-        if (verse) {
-          onVerseChange(verse.ayah);
-        }
-      }
-    }, 200);
-
-    return () => clearInterval(interval);
-  }, [player, timing, isPlaying, onVerseChange]);
-
-  const togglePlay = () => {
-    if (player.playing) {
-      player.pause();
-    } else {
-      player.play();
-    }
+  const formatTime = (ms: number): string => {
+    const totalSec = Math.floor(ms / 1000);
+    const min = Math.floor(totalSec / 60);
+    const sec = totalSec % 60;
+    return `${min}:${sec.toString().padStart(2, "0")}`;
   };
+
+  const buttonLabel = hasEnded ? "↻" : isPlaying ? "⏸" : "▶";
 
   return (
     <View style={styles.container}>
-      <Button title={isPlaying ? "Pause" : "Play"} onPress={togglePlay} />
-      <Text>{isPlaying ? "Playing" : "Paused"}</Text>
+      <TouchableOpacity
+        style={styles.playButton}
+        onPress={toggle}
+        disabled={!isLoaded}
+        accessibilityLabel={
+          hasEnded ? "إعادة التشغيل" : isPlaying ? "إيقاف مؤقت" : "تشغيل"
+        }
+        accessibilityRole="button"
+      >
+        <Text style={[styles.playIcon, !isLoaded && styles.disabled]}>
+          {buttonLabel}
+        </Text>
+      </TouchableOpacity>
+
+      <View style={styles.progressSection}>
+        <View style={styles.progressBar}>
+          <View style={[styles.progressFill, { flex: progress }]} />
+          <View style={{ flex: 1 - progress }} />
+        </View>
+        <View style={styles.timeRow}>
+          <Text style={styles.timeText}>{formatTime(currentTimeMs)}</Text>
+          <Text style={styles.timeText}>{formatTime(durationMs)}</Text>
+        </View>
+      </View>
     </View>
   );
-};
+}
 
 const styles = StyleSheet.create({
   container: {
-    padding: 10,
-    backgroundColor: '#eee',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    height: 60,
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#1B5E20",
+    paddingHorizontal: 12,
+  },
+  playButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(255,255,255,0.2)",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 12,
+  },
+  playIcon: {
+    fontSize: 18,
+    color: "#fff",
+  },
+  disabled: {
+    opacity: 0.4,
+  },
+  progressSection: {
+    flex: 1,
+  },
+  progressBar: {
+    height: 4,
+    backgroundColor: "rgba(255,255,255,0.2)",
+    borderRadius: 2,
+    flexDirection: "row",
+    overflow: "hidden",
+  },
+  progressFill: {
+    backgroundColor: "#A5D6A7",
+    borderRadius: 2,
+  },
+  timeRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 4,
+  },
+  timeText: {
+    fontSize: 11,
+    color: "rgba(255,255,255,0.7)",
   },
 });

--- a/src/hooks/useRecitationPlayer.ts
+++ b/src/hooks/useRecitationPlayer.ts
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useAudioPlayer,
+  useAudioPlayerStatus,
+  setAudioModeAsync,
+} from "expo-audio";
+import {
+  getChapterTiming,
+  getAudioUrl,
+  type ChapterTiming,
+} from "../services/AyahTimingService";
+
+const DEFAULT_RECITER_ID = 1;
+const POLL_INTERVAL_MS = 200;
+
+// Configure audio mode once (iOS silent mode + background playback)
+setAudioModeAsync({
+  playsInSilentMode: true,
+  shouldPlayInBackground: true,
+}).catch(() => {});
+
+export interface RecitationState {
+  isPlaying: boolean;
+  isLoaded: boolean;
+  activeVerse: number | null;
+  currentTimeMs: number;
+  durationMs: number;
+  progress: number;
+  hasEnded: boolean;
+  toggle: () => void;
+  seekToVerse: (verseNumber: number) => void;
+  reset: () => void;
+}
+
+export function useRecitationPlayer(chapterId: number): RecitationState {
+  const initialUrl = getAudioUrl(DEFAULT_RECITER_ID, chapterId);
+  const player = useAudioPlayer(initialUrl);
+  const status = useAudioPlayerStatus(player);
+
+  const [activeVerse, setActiveVerse] = useState<number | null>(null);
+  const [hasEnded, setHasEnded] = useState(false);
+  const timingRef = useRef<ChapterTiming | null>(null);
+  const toggleInProgress = useRef(false);
+  const prevChapterRef = useRef(chapterId);
+
+  // On chapter change: pause, replace source, reset state
+  useEffect(() => {
+    if (prevChapterRef.current === chapterId) {
+      // Initial mount — just load timing
+      timingRef.current = getChapterTiming(DEFAULT_RECITER_ID, chapterId);
+      return;
+    }
+    prevChapterRef.current = chapterId;
+
+    player.pause();
+    const newUrl = getAudioUrl(DEFAULT_RECITER_ID, chapterId);
+    if (newUrl) {
+      player.replace(newUrl);
+    }
+    timingRef.current = getChapterTiming(DEFAULT_RECITER_ID, chapterId);
+    setActiveVerse(null);
+    setHasEnded(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chapterId]);
+
+  // Polling loop for verse synchronization — filter ayah=0 (Bismillah)
+  useEffect(() => {
+    if (!status.playing) return;
+
+    const interval = setInterval(() => {
+      const timing = timingRef.current;
+      if (!timing) return;
+
+      const timeMs = player.currentTime * 1000;
+      const entry = timing.aya_timing.find(
+        (t) => timeMs >= t.start_time && timeMs < t.end_time,
+      );
+
+      if (entry && entry.ayah > 0) {
+        setActiveVerse((prev) =>
+          prev !== entry.ayah ? entry.ayah : prev,
+        );
+      } else if (entry && entry.ayah === 0) {
+        setActiveVerse(null);
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [status.playing, player]);
+
+  // Detect end of chapter
+  useEffect(() => {
+    if (status.didJustFinish) {
+      setHasEnded(true);
+      setActiveVerse(null);
+    }
+  }, [status.didJustFinish]);
+
+  const toggle = useCallback(async () => {
+    if (toggleInProgress.current) return;
+    toggleInProgress.current = true;
+    try {
+      if (hasEnded) {
+        await player.seekTo(0);
+        setHasEnded(false);
+        player.play();
+        return;
+      }
+      if (player.playing) {
+        player.pause();
+      } else {
+        player.play();
+      }
+    } finally {
+      toggleInProgress.current = false;
+    }
+  }, [player, hasEnded]);
+
+  const seekToVerse = useCallback(
+    async (verseNumber: number) => {
+      const timing = timingRef.current;
+      if (!timing) return;
+      const entry = timing.aya_timing.find((t) => t.ayah === verseNumber);
+      if (entry) {
+        await player.seekTo(entry.start_time / 1000);
+        setHasEnded(false);
+      }
+    },
+    [player],
+  );
+
+  const reset = useCallback(async () => {
+    player.pause();
+    await player.seekTo(0);
+    setActiveVerse(null);
+    setHasEnded(false);
+  }, [player]);
+
+  const currentTimeMs = status.currentTime * 1000;
+  const durationMs = status.duration * 1000;
+  const progress =
+    durationMs > 0 ? Math.min(1, Math.max(0, currentTimeMs / durationMs)) : 0;
+
+  return {
+    isPlaying: status.playing,
+    isLoaded: status.isLoaded,
+    activeVerse,
+    currentTimeMs,
+    durationMs,
+    progress,
+    hasEnded,
+    toggle,
+    seekToVerse,
+    reset,
+  };
+}

--- a/src/screens/MushafScreen.tsx
+++ b/src/screens/MushafScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Dimensions,
   FlatList,
@@ -9,6 +9,7 @@ import {
 import { AudioPlayerBar } from "../components/AudioPlayerBar";
 import { QuranPage } from "../components/QuranPage";
 import { databaseService } from "../services/SQLiteService";
+import { versePageIndex } from "../services/VersePageIndex";
 
 const { height, width } = Dimensions.get("window");
 
@@ -19,25 +20,39 @@ type ViewableItemsChangedInfo = {
 export function MushafScreen() {
   const [currentChapter, setCurrentChapter] = useState(1);
   const [activeVerse, setActiveVerse] = useState<number | null>(null);
+  const currentChapterRef = useRef(1);
+  const currentPageRef = useRef(1);
+  const flatListRef = useRef<FlatList<number>>(null);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastScrollTargetRef = useRef<number | null>(null);
+  const updateGenRef = useRef(0);
   const pages = Array.from({ length: 604 }, (_, i) => i + 1);
 
-  async function updateChapter(pageNumber: number) {
+  useEffect(() => {
+    return () => {
+      if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+    };
+  }, []);
+
+  const updateChapter = useCallback(async (pageNumber: number) => {
+    const gen = ++updateGenRef.current;
     try {
       const page = await databaseService.getPageByNumber(pageNumber);
+      if (gen !== updateGenRef.current) return;
 
       const chapterNum = page?.verses1441?.[0]?.chapter_id ?? null;
       if (chapterNum) {
         const chapter = await databaseService.getChapterByNumber(chapterNum);
+        if (gen !== updateGenRef.current) return;
         if (chapter) {
-          setCurrentChapter((prev) =>
-            chapter.number !== prev ? chapter.number : prev,
-          );
+          currentChapterRef.current = chapter.number;
+          setCurrentChapter(chapter.number);
         }
       }
-    } catch (error) {
-      console.log("Error getting chapter", error);
+    } catch {
+      // Non-critical chapter lookup failure
     }
-  }
+  }, []);
 
   const onViewableItemsChanged = useRef(
     ({ viewableItems }: ViewableItemsChangedInfo) => {
@@ -48,14 +63,36 @@ export function MushafScreen() {
           : Number.parseInt(first?.key ?? "", 10);
 
       if (Number.isFinite(pageNum)) {
+        currentPageRef.current = pageNum;
         void updateChapter(pageNum);
       }
     },
   ).current;
 
+  const handleVerseChange = useCallback(
+    (verseNumber: number | null) => {
+      setActiveVerse(verseNumber);
+      if (verseNumber === null || verseNumber === 0) return;
+
+      const chapter = currentChapterRef.current;
+      const page = currentPageRef.current;
+      versePageIndex
+        .getPageForVerse(chapter, verseNumber)
+        .then((targetPage) => {
+          if (!targetPage || targetPage === page) return;
+          const index = targetPage - 1;
+          lastScrollTargetRef.current = index;
+          flatListRef.current?.scrollToIndex({ index, animated: true });
+        })
+        .catch(() => {});
+    },
+    [],
+  );
+
   return (
     <View style={styles.container}>
       <FlatList
+        ref={flatListRef}
         data={pages}
         getItemLayout={(_, index) => ({
           index,
@@ -67,6 +104,14 @@ export function MushafScreen() {
         inverted
         keyExtractor={(item) => item.toString()}
         maxToRenderPerBatch={2}
+        onScrollToIndexFailed={({ index }) => {
+          if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+          retryTimerRef.current = setTimeout(() => {
+            if (lastScrollTargetRef.current === index) {
+              flatListRef.current?.scrollToIndex({ index, animated: true });
+            }
+          }, 500);
+        }}
         onViewableItemsChanged={onViewableItemsChanged}
         pagingEnabled
         removeClippedSubviews
@@ -83,12 +128,10 @@ export function MushafScreen() {
         viewabilityConfig={{ itemVisiblePercentThreshold: 50 }}
         windowSize={3}
       />
-      <View style={{ height: 60 }}>
-        {/* <AudioPlayerBar
-          chapterNumber={currentChapter}
-          onVerseChange={(verse) => setActiveVerse(verse)}
-        /> */}
-      </View>
+      <AudioPlayerBar
+        chapterNumber={currentChapter}
+        onVerseChange={handleVerseChange}
+      />
     </View>
   );
 }

--- a/src/services/AyahTimingService.ts
+++ b/src/services/AyahTimingService.ts
@@ -1,6 +1,73 @@
-export const loadTiming = async (reciterId: number) => {
-  if (reciterId === 1) {
-    return require('../../assets/ayah_timing/read_1.json');
-  }
-  return null;
+export interface AyahTiming {
+  ayah: number;
+  start_time: number;
+  end_time: number;
+}
+
+export interface ChapterTiming {
+  id: number;
+  name: string;
+  aya_timing: AyahTiming[];
+}
+
+export interface ReciterTiming {
+  id: number;
+  name: string;
+  name_en: string;
+  rewaya: string;
+  folder_url: string;
+  chapters: ChapterTiming[];
+}
+
+const TIMING_FILES: Record<number, () => ReciterTiming> = {
+  1: () => require("../../assets/ayah_timing/read_1.json"),
+  5: () => require("../../assets/ayah_timing/read_5.json"),
+  9: () => require("../../assets/ayah_timing/read_9.json"),
+  10: () => require("../../assets/ayah_timing/read_10.json"),
+  31: () => require("../../assets/ayah_timing/read_31.json"),
+  32: () => require("../../assets/ayah_timing/read_32.json"),
+  51: () => require("../../assets/ayah_timing/read_51.json"),
+  53: () => require("../../assets/ayah_timing/read_53.json"),
+  60: () => require("../../assets/ayah_timing/read_60.json"),
+  62: () => require("../../assets/ayah_timing/read_62.json"),
+  67: () => require("../../assets/ayah_timing/read_67.json"),
+  74: () => require("../../assets/ayah_timing/read_74.json"),
+  78: () => require("../../assets/ayah_timing/read_78.json"),
+  106: () => require("../../assets/ayah_timing/read_106.json"),
+  112: () => require("../../assets/ayah_timing/read_112.json"),
+  118: () => require("../../assets/ayah_timing/read_118.json"),
+  159: () => require("../../assets/ayah_timing/read_159.json"),
+  256: () => require("../../assets/ayah_timing/read_256.json"),
 };
+
+const timingCache = new Map<number, ReciterTiming>();
+
+export function loadTiming(reciterId: number): ReciterTiming | null {
+  const cached = timingCache.get(reciterId);
+  if (cached) return cached;
+  const loader = TIMING_FILES[reciterId];
+  if (!loader) return null;
+  try {
+    const timing = loader();
+    timingCache.set(reciterId, timing);
+    return timing;
+  } catch {
+    return null;
+  }
+}
+
+export function getChapterTiming(
+  reciterId: number,
+  chapterId: number,
+): ChapterTiming | null {
+  const reciter = loadTiming(reciterId);
+  if (!reciter) return null;
+  return reciter.chapters.find((c) => c.id === chapterId) ?? null;
+}
+
+export function getAudioUrl(reciterId: number, chapterId: number): string {
+  const reciter = loadTiming(reciterId);
+  if (!reciter) return "";
+  const paddedChapter = chapterId.toString().padStart(3, "0");
+  return `${reciter.folder_url}${paddedChapter}.mp3`;
+}

--- a/src/services/VersePageIndex.ts
+++ b/src/services/VersePageIndex.ts
@@ -1,0 +1,50 @@
+import { databaseService } from "./SQLiteService";
+
+type VerseKey = string;
+
+class VersePageIndexService {
+  private index: Map<VerseKey, number> | null = null;
+  private buildPromise: Promise<Map<VerseKey, number>> | null = null;
+
+  async getIndex(): Promise<Map<VerseKey, number>> {
+    if (this.index) return this.index;
+    if (this.buildPromise) return this.buildPromise;
+    this.buildPromise = this.build()
+      .then((map) => {
+        this.index = map;
+        return map;
+      })
+      .catch((err) => {
+        this.buildPromise = null;
+        throw err;
+      });
+    return this.buildPromise;
+  }
+
+  private async build(): Promise<Map<VerseKey, number>> {
+    const db = await databaseService.getDb();
+    const rows = await db.getAllAsync<{
+      chapter_id: number;
+      number: number;
+      page1441_id: number;
+    }>(
+      "SELECT chapter_id, number, page1441_id FROM verses WHERE page1441_id IS NOT NULL",
+    );
+
+    const map = new Map<VerseKey, number>();
+    for (const row of rows) {
+      map.set(`${row.chapter_id}:${row.number}`, row.page1441_id);
+    }
+    return map;
+  }
+
+  async getPageForVerse(
+    chapterId: number,
+    verseNumber: number,
+  ): Promise<number | null> {
+    const index = await this.getIndex();
+    return index.get(`${chapterId}:${verseNumber}`) ?? null;
+  }
+}
+
+export const versePageIndex = new VersePageIndexService();


### PR DESCRIPTION
## Summary

- Integrates audio recitation player with real-time verse highlighting using bundled timing data
- 18 reciters supported (default: Ibrahim Al-Akdar), with timing JSON files already in `assets/ayah_timing/`
- Verse highlights sync in real-time as audio plays, using existing `QuranPage.renderHighlights()` infrastructure
- Auto-page-advance: app scrolls to the correct page when recitation crosses page boundaries

## Architecture

| File | What |
|------|------|
| `src/services/AyahTimingService.ts` | Typed timing service with module-level cache, safe `require()`, 18-reciter support |
| `src/services/VersePageIndex.ts` | SQLite-backed `(chapter, verse) → page` lookup, built once, retry-on-failure |
| `src/hooks/useRecitationPlayer.ts` | Core hook: `useAudioPlayer` + `useAudioPlayerStatus`, 200ms polling, `didJustFinish` end detection |
| `src/components/AudioPlayerBar.tsx` | 60px styled bar: play/pause/replay button + progress bar + time display |
| `src/screens/MushafScreen.tsx` | Wiring: FlatList ref, auto-scroll, generation counter for chapter lookups |

## Key Design Decisions

- **`useAudioPlayerStatus` + 200ms polling** — Reactive status for UI, polling only for verse timing sync (200ms = imperceptible lag)
- **`setAudioModeAsync({ playsInSilentMode: true, shouldPlayInBackground: true })`** — iOS silent mode and background playback
- **`player.replace()` on chapter change** — Pauses old audio, replaces source on single player instance (no dual-audio overlap)
- **`didJustFinish`** for end detection — No false positive on manual pause (unlike time-based detection)
- **`ayah=0` filtered** — Bismillah timing entries don't set `activeVerse` (no verse 0 in DB)
- **Generation counter** in `updateChapter` — Rapid page swipes discard stale async DB results
- **Ref-first pattern** for `currentChapter` — `currentChapterRef` updated before `setState` for race-safe auto-scroll
- **`toggleInProgress` guard** — Prevents concurrent toggle calls during async seek-to-0

## Test plan

- [ ] Open app, audio bar visible at bottom (green, 60px)
- [ ] Tap play — audio starts for current chapter, first verse highlights
- [ ] Watch verses highlight in sequence as audio plays (200ms sync precision)
- [ ] When recitation crosses page boundary, app auto-scrolls to next page
- [ ] Tap pause — audio pauses, verse highlight stays
- [ ] Tap play again — resumes from where paused
- [ ] When chapter finishes — replay icon shown, verse highlight clears
- [ ] Tap replay — starts from beginning
- [ ] Navigate to different chapter while playing — old audio stops, new chapter loads
- [ ] Test on iOS with ringer switch set to silent — audio should still play
- [ ] Swipe pages rapidly while playing — chapter display stays correct (no stale state)
- [ ] Double-tap play button quickly — no audio glitches

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audio player now displays a progress bar showing current playback time and total duration.
  * Selecting a verse automatically navigates to the corresponding page.

* **UI Improvements**
  * Redesigned audio player controls with updated button styling and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->