### PR TITLE
feat: Add Tafsir El Mouyasser via long-press popup

### DIFF
--- a/src/components/QuranPage.tsx
+++ b/src/components/QuranPage.tsx
@@ -31,13 +31,21 @@ const resolveLineImage = (pageNumber: number, lineIndex: number): number | undef
   return pageImages[lineIndex];
 };
 
+export interface VerseLongPressEvent {
+  verseID: number;
+  verseNumber: number;
+  chapterId: number;
+  pageNumber: number;
+}
+
 interface Props {
   pageNumber: number;
   activeChapter?: number;
   activeVerse?: number | null;
+  onVerseLongPress?: (event: VerseLongPressEvent) => void;
 }
 
-export const QuranPage: React.FC<Props> = ({ pageNumber, activeChapter, activeVerse }) => {
+export const QuranPage: React.FC<Props> = ({ pageNumber, activeChapter, activeVerse, onVerseLongPress }) => {
   const { page, loading, error, retry } = useQuranPage(pageNumber);
 
    const markersByLine = React.useMemo(() => {
@@ -56,6 +64,61 @@ export const QuranPage: React.FC<Props> = ({ pageNumber, activeChapter, activeVe
     }
     return map;
   }, [page]);
+
+  const verseContentByLine = React.useMemo(() => {
+    const map = new Map<number, Array<{ verseID: number; number: number; chapterId: number; minX: number; maxX: number }>>();
+    if (!page) return map;
+
+    for (const verse of page.verses1441) {
+      if (verse.chapter_id === null) continue;
+      for (const h of verse.highlights1441) {
+        const list = map.get(h.line) ?? [];
+        const existing = list.find((v) => v.verseID === verse.verseID);
+        if (existing) {
+          existing.minX = Math.min(existing.minX, h.left_position);
+          existing.maxX = Math.max(existing.maxX, h.right_position);
+        } else {
+          list.push({
+            verseID: verse.verseID,
+            number: verse.number,
+            chapterId: verse.chapter_id,
+            minX: h.left_position,
+            maxX: h.right_position,
+          });
+        }
+        map.set(h.line, list);
+      }
+    }
+    return map;
+  }, [page]);
+
+  const renderVerseContentAreas = (lineIndex: number) => {
+    if (!onVerseLongPress) return null;
+    const items = verseContentByLine.get(lineIndex);
+    if (!items) return null;
+
+    return items.map((v, i) => (
+      <TouchableOpacity
+        key={`verse-area-${v.verseID}-${lineIndex}-${i}`}
+        style={{
+          position: "absolute",
+          left: v.minX * width,
+          width: (v.maxX - v.minX) * width,
+          height: "100%",
+          backgroundColor: "transparent",
+        }}
+        activeOpacity={1}
+        onLongPress={() =>
+          onVerseLongPress({
+            verseID: v.verseID,
+            verseNumber: v.number,
+            chapterId: v.chapterId,
+            pageNumber,
+          })
+        }
+      />
+    ));
+  };
 
   const renderSurahTitleBackgrounds = (lineIndex: number) => {
     if (!page) return null;
@@ -116,6 +179,7 @@ export const QuranPage: React.FC<Props> = ({ pageNumber, activeChapter, activeVe
           {renderSurahTitleBackgrounds(i)}
           {renderVerseMarkers(i)}
           {renderHighlights(i)}
+          {renderVerseContentAreas(i)}
         </View>,
       );
     }

--- a/src/components/TafsirPopup.tsx
+++ b/src/components/TafsirPopup.tsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useRef } from "react";
+import {
+  View,
+  Text,
+  Modal,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  Animated,
+  useWindowDimensions,
+} from "react-native";
+import { useTafsir } from "../hooks/useTafsir";
+import { toArabicDigits } from "../utils/toArabicDigits";
+
+interface TafsirPopupProps {
+  visible: boolean;
+  chapterId: number | null;
+  verseNumber: number | null;
+  chapterName?: string;
+  onClose: () => void;
+}
+
+export function TafsirPopup({
+  visible,
+  chapterId,
+  verseNumber,
+  chapterName,
+  onClose,
+}: TafsirPopupProps) {
+  const { height: screenHeight } = useWindowDimensions();
+  const sheetHeight = screenHeight * 0.55;
+
+  const { tafsir, loading, error, retry } = useTafsir(
+    visible ? chapterId : null,
+    visible ? verseNumber : null,
+  );
+
+  const slideAnim = useRef(new Animated.Value(screenHeight)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.spring(slideAnim, {
+        toValue: 0,
+        useNativeDriver: true,
+        tension: 65,
+        friction: 11,
+      }).start();
+    } else {
+      slideAnim.stopAnimation();
+      slideAnim.setValue(sheetHeight);
+    }
+  }, [visible, slideAnim, sheetHeight]);
+
+  const handleClose = () => {
+    Animated.timing(slideAnim, {
+      toValue: sheetHeight,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => onClose());
+  };
+
+  return (
+    <Modal
+      transparent
+      visible={visible}
+      animationType="fade"
+      onRequestClose={handleClose}
+    >
+      <TouchableOpacity
+        style={styles.overlay}
+        activeOpacity={1}
+        onPress={handleClose}
+      >
+        <Animated.View
+          style={[
+            styles.sheet,
+            { maxHeight: sheetHeight, transform: [{ translateY: slideAnim }] },
+          ]}
+        >
+          <View onStartShouldSetResponder={() => true}>
+            <View style={styles.handleBar} />
+
+            <View style={styles.header}>
+              <Text style={styles.title}>التفسير الميسر</Text>
+              {chapterName && verseNumber !== null && (
+                <Text style={styles.subtitle}>
+                  سورة {chapterName} - الآية {toArabicDigits(verseNumber)}
+                </Text>
+              )}
+            </View>
+
+            <ScrollView
+              style={[styles.content, { maxHeight: sheetHeight - 150 }]}
+              contentContainerStyle={styles.contentContainer}
+              showsVerticalScrollIndicator
+            >
+              {loading && (
+                <View style={styles.centerContent}>
+                  <ActivityIndicator size="large" color="#1B5E20" />
+                  <Text style={styles.loadingText}>جاري تحميل التفسير...</Text>
+                </View>
+              )}
+
+              {error && !loading && (
+                <View style={styles.centerContent}>
+                  <Text style={styles.errorText}>{error}</Text>
+                  <TouchableOpacity style={styles.retryButton} onPress={retry}>
+                    <Text style={styles.retryText}>إعادة المحاولة</Text>
+                  </TouchableOpacity>
+                </View>
+              )}
+
+              {tafsir && !loading && (
+                <Text style={styles.tafsirText}>{tafsir.text}</Text>
+              )}
+            </ScrollView>
+
+            <View style={styles.footer}>
+              <TouchableOpacity
+                style={styles.closeButton}
+                onPress={handleClose}
+              >
+                <Text style={styles.closeButtonText}>إغلاق</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </Animated.View>
+      </TouchableOpacity>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.4)",
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    backgroundColor: "#FFFFFF",
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: -3 },
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    elevation: 10,
+  },
+  handleBar: {
+    width: 40,
+    height: 4,
+    backgroundColor: "#D0D0D0",
+    borderRadius: 2,
+    alignSelf: "center",
+    marginTop: 10,
+    marginBottom: 6,
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#E8E8E8",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "bold",
+    color: "#1B5E20",
+  },
+  subtitle: {
+    fontSize: 13,
+    color: "#888",
+    marginTop: 4,
+  },
+  content: {},
+  contentContainer: {
+    padding: 20,
+  },
+  centerContent: {
+    alignItems: "center",
+    paddingVertical: 30,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: "#888",
+  },
+  errorText: {
+    fontSize: 14,
+    color: "#D32F2F",
+    textAlign: "center",
+    marginBottom: 12,
+  },
+  retryButton: {
+    backgroundColor: "#1B5E20",
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: "#FFFFFF",
+    fontWeight: "600",
+  },
+  tafsirText: {
+    fontSize: 18,
+    lineHeight: 32,
+    color: "#1B1B1B",
+    textAlign: "right",
+    writingDirection: "rtl",
+  },
+  footer: {
+    padding: 12,
+    borderTopWidth: 1,
+    borderTopColor: "#E8E8E8",
+    alignItems: "center",
+  },
+  closeButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 30,
+    borderRadius: 8,
+    backgroundColor: "#F5F5F5",
+  },
+  closeButtonText: {
+    fontSize: 16,
+    color: "#666",
+    fontWeight: "600",
+  },
+});

--- a/src/hooks/useTafsir.ts
+++ b/src/hooks/useTafsir.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { tafsirService, TafsirEntry } from "../services/TafsirService";
+
+interface UseTafsirResult {
+  tafsir: TafsirEntry | null;
+  loading: boolean;
+  error: string | null;
+  retry: () => void;
+}
+
+export function useTafsir(
+  chapterId: number | null,
+  verseNumber: number | null,
+): UseTafsirResult {
+  const [tafsir, setTafsir] = useState<TafsirEntry | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const activeRequest = useRef(0);
+
+  const loadTafsir = useCallback(async () => {
+    if (chapterId === null || verseNumber === null) {
+      setTafsir(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const requestId = ++activeRequest.current;
+    setTafsir(null);
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await tafsirService.getTafsir(chapterId, verseNumber);
+
+      if (requestId !== activeRequest.current) return;
+
+      if (result) {
+        setTafsir(result);
+      } else {
+        setError("لم يتم العثور على التفسير");
+      }
+    } catch {
+      if (requestId !== activeRequest.current) return;
+      setError("حدث خطأ أثناء تحميل التفسير");
+    } finally {
+      if (requestId === activeRequest.current) {
+        setLoading(false);
+      }
+    }
+  }, [chapterId, verseNumber]);
+
+  useEffect(() => {
+    loadTafsir();
+  }, [loadTafsir]);
+
+  return { tafsir, loading, error, retry: loadTafsir };
+}

--- a/src/screens/MushafScreen.tsx
+++ b/src/screens/MushafScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import {
   Dimensions,
   FlatList,
@@ -7,7 +7,8 @@ import {
   ViewToken,
 } from "react-native";
 import { AudioPlayerBar } from "../components/AudioPlayerBar";
-import { QuranPage } from "../components/QuranPage";
+import { QuranPage, VerseLongPressEvent } from "../components/QuranPage";
+import { TafsirPopup } from "../components/TafsirPopup";
 import { databaseService } from "../services/SQLiteService";
 
 const { height, width } = Dimensions.get("window");
@@ -19,6 +20,12 @@ type ViewableItemsChangedInfo = {
 export function MushafScreen() {
   const [currentChapter, setCurrentChapter] = useState(1);
   const [activeVerse, setActiveVerse] = useState<number | null>(null);
+  const [tafsirState, setTafsirState] = useState<{
+    visible: boolean;
+    chapterId: number | null;
+    verseNumber: number | null;
+    chapterName: string;
+  }>({ visible: false, chapterId: null, verseNumber: null, chapterName: "" });
   const pages = Array.from({ length: 604 }, (_, i) => i + 1);
 
   async function updateChapter(pageNumber: number) {
@@ -38,6 +45,27 @@ export function MushafScreen() {
       console.log("Error getting chapter", error);
     }
   }
+
+  const handleVerseLongPress = useCallback(
+    async (event: VerseLongPressEvent) => {
+      let chapterName = "";
+      try {
+        const chapter = await databaseService.getChapterByNumber(
+          event.chapterId,
+        );
+        chapterName = chapter?.arabicTitle ?? "";
+      } catch {
+        // Use empty chapter name if lookup fails
+      }
+      setTafsirState({
+        visible: true,
+        chapterId: event.chapterId,
+        verseNumber: event.verseNumber,
+        chapterName,
+      });
+    },
+    [],
+  );
 
   const onViewableItemsChanged = useRef(
     ({ viewableItems }: ViewableItemsChangedInfo) => {
@@ -75,6 +103,7 @@ export function MushafScreen() {
             <QuranPage
               activeChapter={currentChapter}
               activeVerse={activeVerse}
+              onVerseLongPress={handleVerseLongPress}
               pageNumber={item}
             />
           </View>
@@ -89,6 +118,15 @@ export function MushafScreen() {
           onVerseChange={(verse) => setActiveVerse(verse)}
         /> */}
       </View>
+      <TafsirPopup
+        visible={tafsirState.visible}
+        chapterId={tafsirState.chapterId}
+        verseNumber={tafsirState.verseNumber}
+        chapterName={tafsirState.chapterName}
+        onClose={() =>
+          setTafsirState((prev) => ({ ...prev, visible: false }))
+        }
+      />
     </View>
   );
 }

--- a/src/services/TafsirService.ts
+++ b/src/services/TafsirService.ts
@@ -1,0 +1,165 @@
+import * as SQLite from "expo-sqlite";
+
+const TAFSIR_DB = "tafsir_cache.db";
+const TAFSIR_TABLE = "tafsir_muyassar";
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+// Quran.com API v4 — Tafsir Al-Muyassar (resource id 16)
+const API_BASE = "https://api.quran.com/api/v4";
+const TAFSIR_RESOURCE_ID = 16;
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+}
+
+export interface TafsirEntry {
+  chapterId: number;
+  verseNumber: number;
+  text: string;
+}
+
+type SQLiteDb = Awaited<ReturnType<typeof SQLite.openDatabaseAsync>>;
+
+class TafsirService {
+  private db: SQLiteDb | null = null;
+  private initPromise: Promise<SQLiteDb> | null = null;
+
+  private async getDb(): Promise<SQLiteDb> {
+    if (this.db) return this.db;
+    if (!this.initPromise) {
+      this.initPromise = this.initDatabase()
+        .then((db) => {
+          this.db = db;
+          return db;
+        })
+        .catch((e) => {
+          this.initPromise = null;
+          throw e;
+        });
+    }
+    return this.initPromise;
+  }
+
+  private async initDatabase(): Promise<SQLiteDb> {
+    const db = await SQLite.openDatabaseAsync(TAFSIR_DB);
+    await db.execAsync(`
+      CREATE TABLE IF NOT EXISTS ${TAFSIR_TABLE} (
+        chapter_id INTEGER NOT NULL,
+        verse_number INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        fetched_at INTEGER NOT NULL,
+        PRIMARY KEY (chapter_id, verse_number)
+      )
+    `);
+    return db;
+  }
+
+  async getTafsir(
+    chapterId: number,
+    verseNumber: number,
+  ): Promise<TafsirEntry | null> {
+    if (chapterId < 1 || chapterId > 114 || verseNumber < 1) return null;
+
+    // Try cache first
+    const cached = await this.getFromCache(chapterId, verseNumber);
+    if (cached) return cached;
+
+    // Fetch from API
+    const fetched = await this.fetchFromApi(chapterId, verseNumber);
+    if (fetched) {
+      await this.saveToCache(fetched);
+      return fetched;
+    }
+
+    return null;
+  }
+
+  private async getFromCache(
+    chapterId: number,
+    verseNumber: number,
+  ): Promise<TafsirEntry | null> {
+    try {
+      const db = await this.getDb();
+      const row = await db.getFirstAsync<{
+        chapter_id: number;
+        verse_number: number;
+        text: string;
+      }>(
+        `SELECT chapter_id, verse_number, text FROM ${TAFSIR_TABLE} WHERE chapter_id = ? AND verse_number = ? AND fetched_at > ?`,
+        [chapterId, verseNumber, Date.now() - CACHE_TTL_MS],
+      );
+
+      if (row) {
+        return {
+          chapterId: row.chapter_id,
+          verseNumber: row.verse_number,
+          text: row.text,
+        };
+      }
+    } catch (e) {
+      console.warn("[TafsirService] Cache read failed:", e);
+    }
+    return null;
+  }
+
+  private async saveToCache(entry: TafsirEntry): Promise<void> {
+    try {
+      const db = await this.getDb();
+      await db.runAsync(
+        `INSERT OR REPLACE INTO ${TAFSIR_TABLE} (chapter_id, verse_number, text, fetched_at) VALUES (?, ?, ?, ?)`,
+        [entry.chapterId, entry.verseNumber, entry.text, Date.now()],
+      );
+    } catch (e) {
+      console.warn("[TafsirService] Cache write failed:", e);
+    }
+  }
+
+  private async fetchFromApi(
+    chapterId: number,
+    verseNumber: number,
+  ): Promise<TafsirEntry | null> {
+    const ayahKey = `${chapterId}:${verseNumber}`;
+    const url = `${API_BASE}/tafsirs/${TAFSIR_RESOURCE_ID}/by_ayah/${ayahKey}`;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+
+      if (!response.ok) {
+        console.warn(
+          `[TafsirService] API returned ${response.status} for ${ayahKey}`,
+        );
+        return null;
+      }
+
+      const data = await response.json();
+      const tafsirText = data?.tafsir?.text;
+
+      if (typeof tafsirText === "string" && tafsirText.length > 0) {
+        return {
+          chapterId,
+          verseNumber,
+          text: stripHtml(tafsirText),
+        };
+      }
+
+      return null;
+    } catch (e) {
+      console.warn("[TafsirService] API fetch failed:", e);
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export const tafsirService = new TafsirService();


### PR DESCRIPTION
## Summary
- Adds Tafsir Al-Muyassar (التفسير الميسر) display triggered by long-press on any verse
- Fetches tafsir text from quran.com API v4 with local SQLite caching (30-day TTL)
- Animated bottom sheet popup with RTL Arabic text, loading/error states

## Implementation Details

### New Files
- **`src/services/TafsirService.ts`** — API fetch + SQLite cache with HTML tag stripping, input validation, and retry-on-failure for DB init
- **`src/hooks/useTafsir.ts`** — Hook with race condition guard (request counter), stale content clearing
- **`src/components/TafsirPopup.tsx`** — Animated bottom sheet using `useWindowDimensions` for dynamic sizing, spring animation with proper cleanup

### Modified Files
- **`src/components/QuranPage.tsx`** — Added `onVerseLongPress` callback prop and touchable verse content areas computed from highlights1441 position data
- **`src/screens/MushafScreen.tsx`** — Wired long-press to TafsirPopup with atomic state (single `useState` for visible + target)

### Key Design Decisions
- **Container-agnostic**: Core QuranPage only exposes `onVerseLongPress` callback — all tafsir logic lives in the container app
- **Cache-first**: SQLite cache checked before API call; 30-day TTL for freshness
- **HTML stripping**: API returns `<span>` tags in tafsir text — stripped before display/cache
- **Atomic state**: `tafsirState` combines `visible`, `chapterId`, `verseNumber`, and `chapterName` in a single `useState` to prevent race conditions
- **Arabic numerals**: Verse numbers displayed using Eastern-Arabic numerals (٢٨٦) via `toArabicDigits`

## Test plan
- [ ] Long-press on any verse shows tafsir popup with correct content
- [ ] Popup shows loading spinner while fetching
- [ ] Popup shows error + retry button when offline
- [ ] Rapid long-press on different verses shows correct verse each time
- [ ] Android back button dismisses the popup
- [ ] Close button dismisses with slide-down animation
- [ ] Tapping overlay area outside sheet dismisses popup
- [ ] Second open of same verse uses cached data (instant)
- [ ] Arabic text displays RTL with proper line height
- [ ] Verse number in subtitle uses Arabic numerals

Closes #39