### PR TITLE
feat: add floating draggable page jump input (closes #36)

### DIFF
--- a/src/components/page-jump-input.tsx
+++ b/src/components/page-jump-input.tsx
@@ -1,0 +1,235 @@
+import React, { useRef, useState } from "react";
+import {
+  Animated,
+  Dimensions,
+  Keyboard,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { colors } from "../theme";
+
+const MIN_PAGE = 1;
+const MAX_PAGE = 604;
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
+
+type PageJumpInputProps = {
+  currentPage: number;
+  onJumpToPage: (page: number) => void;
+};
+
+export function PageJumpInput({ currentPage, onJumpToPage }: PageJumpInputProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+
+  // Draggable position
+  const pan = useRef(new Animated.ValueXY()).current;
+  const lastOffset = useRef({ x: 0, y: 0 });
+  const isDragging = useRef(false);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (_, gestureState) => {
+        // Only capture drag if moved more than 5px (avoids blocking taps)
+        return Math.abs(gestureState.dx) > 5 || Math.abs(gestureState.dy) > 5;
+      },
+      onPanResponderGrant: () => {
+        isDragging.current = false;
+        pan.setOffset({
+          x: lastOffset.current.x,
+          y: lastOffset.current.y,
+        });
+        pan.setValue({ x: 0, y: 0 });
+      },
+      onPanResponderMove: (_, gestureState) => {
+        isDragging.current = true;
+        Animated.event([null, { dx: pan.x, dy: pan.y }], {
+          useNativeDriver: false,
+        })(_, gestureState);
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        pan.flattenOffset();
+
+        // Clamp within screen bounds
+        const buttonWidth = 140;
+        const buttonHeight = 40;
+        const minX = -(SCREEN_WIDTH / 2 - buttonWidth / 2);
+        const maxX = SCREEN_WIDTH / 2 - buttonWidth / 2;
+        const minY = -(SCREEN_HEIGHT / 2 - buttonHeight);
+        const maxY = SCREEN_HEIGHT / 2 - buttonHeight - 80;
+
+        const clampedX = Math.max(minX, Math.min(maxX, lastOffset.current.x + gestureState.dx));
+        const clampedY = Math.max(minY, Math.min(maxY, lastOffset.current.y + gestureState.dy));
+
+        lastOffset.current = { x: clampedX, y: clampedY };
+
+        Animated.spring(pan, {
+          toValue: { x: clampedX, y: clampedY },
+          useNativeDriver: false,
+          friction: 7,
+        }).start();
+      },
+    }),
+  ).current;
+
+  function handleSubmit() {
+    const page = Number.parseInt(inputValue, 10);
+    if (page >= MIN_PAGE && page <= MAX_PAGE) {
+      onJumpToPage(page);
+    }
+    setInputValue("");
+    setIsEditing(false);
+    Keyboard.dismiss();
+  }
+
+  if (isEditing) {
+    return (
+      <Animated.View
+        style={[
+          styles.floatingContainer,
+          { transform: pan.getTranslateTransform() },
+        ]}
+        {...panResponder.panHandlers}
+      >
+        <View style={styles.editingBubble}>
+          <TextInput
+            autoFocus
+            keyboardType="number-pad"
+            maxLength={3}
+            onBlur={() => {
+              setIsEditing(false);
+              setInputValue("");
+            }}
+            onChangeText={setInputValue}
+            onSubmitEditing={handleSubmit}
+            placeholder={`${MIN_PAGE}-${MAX_PAGE}`}
+            placeholderTextColor={colors.text.tertiary}
+            returnKeyType="go"
+            style={styles.input}
+            value={inputValue}
+          />
+          <Pressable
+            onPress={handleSubmit}
+            style={({ pressed }) => [
+              styles.goButton,
+              pressed && styles.goButtonPressed,
+            ]}
+          >
+            <Text style={styles.goButtonText}>انتقال</Text>
+          </Pressable>
+        </View>
+      </Animated.View>
+    );
+  }
+
+  return (
+    <Animated.View
+      style={[
+        styles.floatingContainer,
+        { transform: pan.getTranslateTransform() },
+      ]}
+      {...panResponder.panHandlers}
+    >
+      <Pressable
+        style={styles.pageBubble}
+        onPress={() => {
+          if (!isDragging.current) {
+            setIsEditing(true);
+          }
+        }}
+      >
+        <Text style={styles.pageLabel}>صفحة</Text>
+        <Text style={styles.pageNumber}>{currentPage}</Text>
+        <Text style={styles.totalPages}>/ {MAX_PAGE}</Text>
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  floatingContainer: {
+    position: "absolute",
+    bottom: 70,
+    alignSelf: "center",
+    zIndex: 100,
+    elevation: 10,
+  },
+  pageBubble: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.background.surface,
+    borderRadius: 24,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 4,
+    shadowColor: colors.shadow.default,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
+    elevation: 8,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+  },
+  editingBubble: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.background.surface,
+    borderRadius: 24,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    gap: 8,
+    shadowColor: colors.shadow.default,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
+    elevation: 8,
+    borderWidth: 1,
+    borderColor: colors.brand.default,
+  },
+  pageLabel: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    fontWeight: "500",
+  },
+  pageNumber: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: colors.brand.default,
+    minWidth: 28,
+    textAlign: "center",
+  },
+  totalPages: {
+    fontSize: 13,
+    color: colors.text.tertiary,
+  },
+  input: {
+    backgroundColor: colors.background.subtle,
+    borderRadius: 16,
+    fontSize: 16,
+    fontWeight: "600",
+    minWidth: 64,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    textAlign: "center",
+    color: colors.text.primary,
+  },
+  goButton: {
+    backgroundColor: colors.brand.default,
+    borderRadius: 16,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+  },
+  goButtonPressed: {
+    opacity: 0.8,
+  },
+  goButtonText: {
+    color: colors.text.inverse,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/src/screens/mushaf-screen.tsx
+++ b/src/screens/mushaf-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import {
   Dimensions,
   FlatList,
@@ -7,6 +7,7 @@ import {
   ViewToken,
 } from "react-native";
 import { AudioPlayerBar } from "../components/audio-player-bar";
+import { PageJumpInput } from "../components/page-jump-input";
 import { QuranPage } from "../components/quran-page";
 import { databaseService } from "../services/sqlite-service";
 import { QuranView } from "../components/quran";
@@ -24,6 +25,8 @@ export function MushafScreen() {
   const setCurrentChapter = useMushafStore((s) => s.setCurrentChapter);
   const activeVerse = useMushafStore((s) => s.activeVerse);
   const pages = Array.from({ length: 604 }, (_, i) => i + 1);
+  const [currentPage, setCurrentPage] = useState(1);
+  const flatListRef = useRef<FlatList<number>>(null);
 
   async function updateChapter(pageNumber: number) {
     try {
@@ -50,14 +53,24 @@ export function MushafScreen() {
           : Number.parseInt(first?.key ?? "", 10);
 
       if (Number.isFinite(pageNum)) {
+        setCurrentPage(pageNum);
         void updateChapter(pageNum);
       }
     },
   ).current;
 
+  const handleJumpToPage = useCallback(
+    (page: number) => {
+      const index = page - 1;
+      flatListRef.current?.scrollToIndex({ index, animated: false });
+    },
+    [],
+  );
+
   return (
     <View style={styles.container}>
       <FlatList
+        ref={flatListRef}
         data={pages}
         getItemLayout={(_, index) => ({
           index,
@@ -85,6 +98,7 @@ export function MushafScreen() {
         viewabilityConfig={{ itemVisiblePercentThreshold: 50 }}
         windowSize={3}
       />
+      <PageJumpInput currentPage={currentPage} onJumpToPage={handleJumpToPage} />
       <View style={{ height: 60 }}>
         {/* <AudioPlayerBar /> */}
       </View>


### PR DESCRIPTION
## Summary

Implements **Jump to page input** as requested in #36. Users can quickly navigate to any page (1–604) via a floating, draggable button.

## Why a floating button instead of a header bar?

We chose a **floating draggable bubble** over a fixed header for several reasons:

1. **Zero content loss** — A fixed header steals vertical space from the Quran page and clips the first line of ayat. The floating button overlays the content without reducing the reading area at all.

2. **Reader freedom** — Everyone holds their phone differently. The floating button can be dragged anywhere on screen — top, bottom, left, right — so it never blocks whatever the reader is currently reading.

3. **Non-intrusive** — If the button happens to cover an ayah, the reader simply drags it out of the way. A fixed header has no such flexibility.

4. **Cleaner UX** — Popular Quran apps use floating controls to minimize distraction and preserve the authentic mushaf page appearance.

5. **Zero extra dependencies** — Uses only React Native built-in `PanResponder` + `Animated` APIs. No third-party libraries needed.

## Changes

- **New file:** `src/components/page-jump-input.tsx`
  - Floating bubble showing current page (e.g. صفحة 300 / 604)
  - Tap to open a number input field + "انتقال" (Go) button
  - Fully draggable via `PanResponder` with screen-bounds clamping
  - Input validation (1–604) before jumping

- **Modified:** `src/screens/mushaf-screen.tsx`
  - Added `FlatList` ref + `scrollToIndex` for instant page jump
  - Tracks current page via `onViewableItemsChanged`
  - Renders `PageJumpInput` as an absolute overlay — no layout impact

## Screenshots

<img width="452" height="604" alt="image" src="https://github.com/user-attachments/assets/53dfecc4-925b-4dba-a5d0-b542eac6db84" />

Closes #36