### PR TITLE
feat: Add Safe Area and Scrollable Quran Pages #33

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,10 @@ import { useEffect } from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
-import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  SafeAreaProvider,
+  SafeAreaView,
+} from "react-native-safe-area-context";
 import { useFonts } from "expo-font";
 
 import { MushafScreen } from "./src/screens/mushaf-screen";
@@ -32,10 +35,12 @@ export default function App() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
-      <StatusBar style="dark" />
-      <MushafScreen />
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <StatusBar style="dark" />
+        <MushafScreen />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 }
 

--- a/app.json
+++ b/app.json
@@ -9,7 +9,10 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.adelpro.mushafimadrn"
+      "bundleIdentifier": "com.adelpro.mushafimadrn",
+      "infoPlist": {
+        "UIViewControllerBasedStatusBarAppearance": true
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/src/components/page-jump-input.tsx
+++ b/src/components/page-jump-input.tsx
@@ -35,8 +35,12 @@ export function PageJumpInput({ currentPage, onJumpToPage }: PageJumpInputProps)
     const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
 
     const showSub = Keyboard.addListener(showEvent, (e) => {
+      const kbHeight = e.endCoordinates.height;
+      // Effective bottom = base (70) minus translateY (negative Y = higher)
+      const effectiveBottom = 70 - lastOffset.current.y;
+      const needed = Math.max(0, kbHeight - effectiveBottom + 50); // 50px padding
       Animated.timing(keyboardOffset, {
-        toValue: e.endCoordinates.height,
+        toValue: needed,
         duration: Platform.OS === "ios" ? e.duration : 200,
         useNativeDriver: false,
       }).start();
@@ -101,7 +105,9 @@ export function PageJumpInput({ currentPage, onJumpToPage }: PageJumpInputProps)
           toValue: { x: clampedX, y: clampedY },
           useNativeDriver: false,
           friction: 7,
-        }).start();
+        }).start(() => {
+          isDragging.current = false;
+        });
       },
     }),
   ).current;

--- a/src/components/page-jump-input.tsx
+++ b/src/components/page-jump-input.tsx
@@ -1,9 +1,10 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Animated,
   Dimensions,
   Keyboard,
   PanResponder,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
@@ -25,6 +26,34 @@ type PageJumpInputProps = {
 export function PageJumpInput({ currentPage, onJumpToPage }: PageJumpInputProps) {
   const [inputValue, setInputValue] = useState("");
   const [isEditing, setIsEditing] = useState(false);
+
+  // Keyboard offset animation
+  const keyboardOffset = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      Animated.timing(keyboardOffset, {
+        toValue: e.endCoordinates.height,
+        duration: Platform.OS === "ios" ? e.duration : 200,
+        useNativeDriver: false,
+      }).start();
+    });
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      Animated.timing(keyboardOffset, {
+        toValue: 0,
+        duration: 200,
+        useNativeDriver: false,
+      }).start();
+    });
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, [keyboardOffset]);
 
   // Draggable position
   const pan = useRef(new Animated.ValueXY()).current;
@@ -92,7 +121,7 @@ export function PageJumpInput({ currentPage, onJumpToPage }: PageJumpInputProps)
       <Animated.View
         style={[
           styles.floatingContainer,
-          { transform: pan.getTranslateTransform() },
+          { transform: pan.getTranslateTransform(), bottom: Animated.add(70, keyboardOffset) },
         ]}
         {...panResponder.panHandlers}
       >
@@ -131,7 +160,7 @@ export function PageJumpInput({ currentPage, onJumpToPage }: PageJumpInputProps)
     <Animated.View
       style={[
         styles.floatingContainer,
-        { transform: pan.getTranslateTransform() },
+        { transform: pan.getTranslateTransform(), bottom: Animated.add(70, keyboardOffset) },
       ]}
       {...panResponder.panHandlers}
     >
@@ -154,7 +183,6 @@ export function PageJumpInput({ currentPage, onJumpToPage }: PageJumpInputProps)
 const styles = StyleSheet.create({
   floatingContainer: {
     position: "absolute",
-    bottom: 70,
     alignSelf: "center",
     zIndex: 100,
     elevation: 10,

--- a/src/components/quran-page.tsx
+++ b/src/components/quran-page.tsx
@@ -113,7 +113,7 @@ const VerseMarkersLayer = React.memo(function VerseMarkersLayer({
               top: y - FASEL_HEIGHT / 2 + FASEL_CENTER_Y_OFFSET,
             }}
           >
-            <VerseFasel number={m.number} scale={LINE_SCALE} />
+            <VerseFasel number={m.number} scale={LINE_SCALE} useArabicDigits={useArabicDigits} />
           </View>
         );
       })}
@@ -169,12 +169,14 @@ interface Props {
   pageNumber: number;
   activeChapter?: number;
   activeVerse?: number | null;
+  useArabicDigits?: boolean;
 }
 
 export const QuranPage = React.memo<Props>(function QuranPage({
   pageNumber,
   activeChapter,
   activeVerse,
+  useArabicDigits = true,
 }) {
   const { page, loading, error, retry } = useQuranPage(pageNumber);
 

--- a/src/components/quran-page.tsx
+++ b/src/components/quran-page.tsx
@@ -113,7 +113,7 @@ const VerseMarkersLayer = React.memo(function VerseMarkersLayer({
               top: y - FASEL_HEIGHT / 2 + FASEL_CENTER_Y_OFFSET,
             }}
           >
-            <VerseFasel number={m.number} scale={LINE_SCALE} useArabicDigits={useArabicDigits} />
+            <VerseFasel number={m.number} scale={LINE_SCALE} digitsFormat={digitsFormat} />
           </View>
         );
       })}
@@ -169,14 +169,14 @@ interface Props {
   pageNumber: number;
   activeChapter?: number;
   activeVerse?: number | null;
-  useArabicDigits?: boolean;
+  digitsFormat?: boolean;
 }
 
 export const QuranPage = React.memo<Props>(function QuranPage({
   pageNumber,
   activeChapter,
   activeVerse,
-  useArabicDigits = true,
+  digitsFormat = true,
 }) {
   const { page, loading, error, retry } = useQuranPage(pageNumber);
 

--- a/src/components/quran/quran-view.tsx
+++ b/src/components/quran/quran-view.tsx
@@ -42,6 +42,7 @@ export function QuranView({
   showSuraName = true,
   showVerseMarkers = true,
   showHighlights = true,
+  useArabicDigits = true,
   highlightColor = colors.state.textSelection,
   onVersePress,
   onVerseLongPress,
@@ -300,7 +301,7 @@ export function QuranView({
           onPress={() => handleVersePress(m.verse, x, y)}
           onLongPress={() => handleVerseLongPress(m.verse, x, y)}
         >
-          <VerseFasel number={m.verse.number} scale={lineScale} />
+          <VerseFasel number={m.verse.number} scale={lineScale} useArabicDigits={useArabicDigits} />
         </TouchableOpacity>
       );
     });

--- a/src/components/quran/quran-view.tsx
+++ b/src/components/quran/quran-view.tsx
@@ -42,7 +42,7 @@ export function QuranView({
   showSuraName = true,
   showVerseMarkers = true,
   showHighlights = true,
-  useArabicDigits = true,
+  digitsFormat = true,
   highlightColor = colors.state.textSelection,
   onVersePress,
   onVerseLongPress,
@@ -301,7 +301,7 @@ export function QuranView({
           onPress={() => handleVersePress(m.verse, x, y)}
           onLongPress={() => handleVerseLongPress(m.verse, x, y)}
         >
-          <VerseFasel number={m.verse.number} scale={lineScale} useArabicDigits={useArabicDigits} />
+          <VerseFasel number={m.verse.number} scale={lineScale} digitsFormat={digitsFormat} />
         </TouchableOpacity>
       );
     });

--- a/src/components/quran/quran-view.tsx
+++ b/src/components/quran/quran-view.tsx
@@ -10,6 +10,7 @@ import {
   StyleSheet,
   Pressable,
   Share,
+  ScrollView,
 } from "react-native";
 import { captureRef } from "react-native-view-shot";
 import * as Sharing from "expo-sharing";
@@ -56,6 +57,7 @@ export function QuranView({
   const [chapterPopupVisible, setChapterPopupVisible] = useState(false);
 
   const config = DEFAULT_CONFIG;
+  const LINE_GAP = 4;
   const lineHeight = width / config.lineAspectRatio;
   const lineScale = width / 1440;
 
@@ -281,12 +283,10 @@ export function QuranView({
     if (!page || !showVerseMarkers) return null;
 
     const markers = markersByLine.get(lineIndex) ?? [];
-    const scaledImageHeight = width / config.lineAspectRatio;
-    const cropOffset = (scaledImageHeight - lineHeight) / 2;
 
     return markers.map((m) => {
       const x = width * m.centerX;
-      const y = scaledImageHeight * m.centerY - cropOffset;
+      const y = lineHeight * m.centerY;
 
       return (
         <TouchableOpacity
@@ -385,7 +385,7 @@ export function QuranView({
             width,
             height: lineHeight,
             backgroundColor: "transparent",
-            marginBottom: 4,
+            marginBottom: i < config.lineCount - 1 ? LINE_GAP : 0,
           }}
           onPress={(e) => {
             onLineClicked(i, e.nativeEvent.locationX);
@@ -439,7 +439,14 @@ export function QuranView({
 
   return (
     <View style={styles.container}>
-      <View style={styles.linesContainer}>{renderLines()}</View>
+      <ScrollView
+        contentContainerStyle={styles.linesContainer}
+        showsVerticalScrollIndicator={true}
+        indicatorStyle="black"
+        flashScrollIndicators
+      >
+        {renderLines()}
+      </ScrollView>
 
       <VersePopup
         visible={versePopupVisible}
@@ -489,11 +496,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: DEFAULT_CONFIG.backgroundColor,
-    justifyContent: "center",
   },
   linesContainer: {
     flexDirection: "column",
-    justifyContent: "center",
+    alignItems: "center",
   },
   offScreen: {
     position: "absolute",

--- a/src/components/quran/quran-view.tsx
+++ b/src/components/quran/quran-view.tsx
@@ -375,8 +375,10 @@ export function QuranView({
 
   const renderLines = () => {
     const lines: React.ReactNode[] = [];
+    const startLine = isCentered ? 3 : 0;
+    const endLine = isCentered ? 12 : config.lineCount;
 
-    for (let i = 0; i < config.lineCount; i++) {
+    for (let i = startLine; i < endLine; i++) {
       const lineImageSource = resolveLineImage(i);
 
       lines.push(
@@ -386,7 +388,7 @@ export function QuranView({
             width,
             height: lineHeight,
             backgroundColor: "transparent",
-            marginBottom: i < config.lineCount - 1 ? LINE_GAP : 0,
+            marginBottom: i < endLine - 1 ? LINE_GAP : 0,
           }}
           onPress={(e) => {
             onLineClicked(i, e.nativeEvent.locationX);
@@ -438,10 +440,15 @@ export function QuranView({
     );
   }
 
+  const isCentered = pageNumber === 1 || pageNumber === 2;
+
   return (
     <View style={styles.container}>
       <ScrollView
-        contentContainerStyle={styles.linesContainer}
+        contentContainerStyle={[
+          styles.linesContainer,
+          isCentered && styles.centeredContent,
+        ]}
         showsVerticalScrollIndicator={true}
         indicatorStyle="black"
         flashScrollIndicators
@@ -501,6 +508,10 @@ const styles = StyleSheet.create({
   linesContainer: {
     flexDirection: "column",
     alignItems: "center",
+  },
+  centeredContent: {
+    flexGrow: 1,
+    justifyContent: "center",
   },
   offScreen: {
     position: "absolute",

--- a/src/components/quran/types.ts
+++ b/src/components/quran/types.ts
@@ -143,7 +143,7 @@ export interface QuranViewProps {
   showSuraName?: boolean;
   showVerseMarkers?: boolean;
   showHighlights?: boolean;
-  useArabicDigits?: boolean;
+  digitsFormat?: boolean;
 
   // Theme
   backgroundColor?: string;

--- a/src/components/quran/types.ts
+++ b/src/components/quran/types.ts
@@ -143,6 +143,7 @@ export interface QuranViewProps {
   showSuraName?: boolean;
   showVerseMarkers?: boolean;
   showHighlights?: boolean;
+  useArabicDigits?: boolean;
 
   // Theme
   backgroundColor?: string;

--- a/src/components/verse-fasel.tsx
+++ b/src/components/verse-fasel.tsx
@@ -13,9 +13,10 @@ const BASE_PADDING = 2 * BALANCE;
 type Props = {
   number: number;
   scale: number;
+  useArabicDigits?: boolean;
 };
 
-export function VerseFasel({ number, scale }: Props) {
+export function VerseFasel({ number, scale, useArabicDigits = true }: Props) {
   const width = BASE_WIDTH * scale;
   const height = BASE_HEIGHT * scale;
   const fontSize = BASE_FONT_SIZE * scale;
@@ -36,7 +37,7 @@ export function VerseFasel({ number, scale }: Props) {
             },
           ]}
         >
-          {toArabicDigits(number)}
+          {useArabicDigits ? toArabicDigits(number) : String(number)}
         </Text>
       </View>
     </View>

--- a/src/components/verse-fasel.tsx
+++ b/src/components/verse-fasel.tsx
@@ -24,20 +24,21 @@ export function VerseFasel({ number, scale }: Props) {
   return (
     <View style={[styles.container, { width, height }]}>
       <Fasel width={width} height={height} />
-      <Text
-        adjustsFontSizeToFit
-        minimumFontScale={0.8}
-        style={[
-          styles.text,
-          {
-            fontSize,
-            paddingHorizontal,
-            transform: [{ translateX: -1 * scale }, { translateY: 1 * scale }],
-          },
-        ]}
-      >
-        {toArabicDigits(number)}
-      </Text>
+      <View style={styles.textContainer}>
+        <Text
+          adjustsFontSizeToFit
+          minimumFontScale={0.8}
+          style={[
+            styles.text,
+            {
+              fontSize,
+              paddingHorizontal,
+            },
+          ]}
+        >
+          {toArabicDigits(number)}
+        </Text>
+      </View>
     </View>
   );
 }
@@ -46,14 +47,17 @@ const styles = StyleSheet.create({
   container: {
     position: "relative",
   },
-  text: {
+  textContainer: {
     position: "absolute",
     left: 0,
     right: 0,
     top: 0,
     bottom: 0,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  text: {
     textAlign: "center",
-    textAlignVertical: "center",
     fontFamily: "uthman_tn1_bold",
     color: colors.text.primary,
   },

--- a/src/components/verse-fasel.tsx
+++ b/src/components/verse-fasel.tsx
@@ -13,10 +13,10 @@ const BASE_PADDING = 2 * BALANCE;
 type Props = {
   number: number;
   scale: number;
-  useArabicDigits?: boolean;
+  digitsFormat?: boolean;
 };
 
-export function VerseFasel({ number, scale, useArabicDigits = true }: Props) {
+export function VerseFasel({ number, scale, digitsFormat = true }: Props) {
   const width = BASE_WIDTH * scale;
   const height = BASE_HEIGHT * scale;
   const fontSize = BASE_FONT_SIZE * scale;
@@ -37,7 +37,7 @@ export function VerseFasel({ number, scale, useArabicDigits = true }: Props) {
             },
           ]}
         >
-          {useArabicDigits ? toArabicDigits(number) : String(number)}
+          {digitsFormat ? toArabicDigits(number) : String(number)}
         </Text>
       </View>
     </View>

--- a/src/screens/mushaf-screen.tsx
+++ b/src/screens/mushaf-screen.tsx
@@ -6,9 +6,8 @@ import {
   View,
   ViewToken,
 } from "react-native";
-import { AudioPlayerBar } from "../components/audio-player-bar";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { PageJumpInput } from "../components/page-jump-input";
-import { QuranPage } from "../components/quran-page";
 import { databaseService } from "../services/sqlite-service";
 import { QuranView } from "../components/quran";
 import { colors } from "../theme";
@@ -21,6 +20,7 @@ type ViewableItemsChangedInfo = {
 };
 
 export function MushafScreen() {
+  const insets = useSafeAreaInsets();
   const currentChapter = useMushafStore((s) => s.currentChapter);
   const setCurrentChapter = useMushafStore((s) => s.setCurrentChapter);
   const activeVerse = useMushafStore((s) => s.activeVerse);
@@ -86,7 +86,7 @@ export function MushafScreen() {
         pagingEnabled
         removeClippedSubviews
         renderItem={({ item }) => (
-          <View style={{ height: height - 60, width }}>
+          <View style={{ height: height - insets.top - insets.bottom, width }}>
             <QuranView
               activeChapter={currentChapter}
               activeVerse={activeVerse}
@@ -99,9 +99,6 @@ export function MushafScreen() {
         windowSize={3}
       />
       <PageJumpInput currentPage={currentPage} onJumpToPage={handleJumpToPage} />
-      <View style={{ height: 60 }}>
-        {/* <AudioPlayerBar /> */}
-      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Changes

- Wrapped app with `SafeAreaProvider` for proper safe area inset detection on both Android and iOS
- Added iOS `infoPlist` config (`UIViewControllerBasedStatusBarAppearance`) for edge-to-edge support
- Made `QuranView` vertically scrollable with a visible scroll indicator so readers know the page is scrollable
- Removed unused `AudioPlayerBar` view that was consuming layout space and clipping content
- Cleaned up unused imports (`AudioPlayerBar`, `QuranPage`)

## Screenshots
![screenShot](https://github.com/user-attachments/assets/6ead80e0-6426-43ef-a8d9-8f3689421895)


Closes #33