### PR TITLE
Add TabFooter and ProgressScreen components with navigation updates

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
@@ -6,6 +6,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useFonts } from "expo-font";
 
 import { MushafScreen } from "./src/screens/mushaf-screen";
+import { ProgressScreen } from "./src/screens/progress-screen";
+import { TabFooter, type TabId } from "./src/components/tab-footer";
 import { colors } from "./src/theme";
 
 SplashScreen.preventAutoHideAsync().catch(() => undefined);
@@ -13,6 +15,8 @@ SplashScreen.preventAutoHideAsync().catch(() => undefined);
 SplashScreen.setOptions({ fade: true, duration: 1000 });
 
 export default function App() {
+  const [activeTab, setActiveTab] = useState<TabId>("mushaf");
+  const [footerVisible, setFooterVisible] = useState(true);
   const [fontsLoaded, fontError] = useFonts({
     uthmanTn1Bold: require("./assets/fonts/UthmanTN1B-Ver20.ttf"),
   });
@@ -34,7 +38,27 @@ export default function App() {
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar style="dark" />
-      <MushafScreen />
+      <View style={styles.content}>
+        {activeTab === "mushaf" && (
+          <View style={styles.tabContent} pointerEvents="auto">
+            <MushafScreen
+              onContentTap={() => setFooterVisible((v) => !v)}
+            />
+          </View>
+        )}
+        {activeTab === "progress" && (
+          <View style={styles.tabContent} pointerEvents="auto">
+            <ProgressScreen />
+          </View>
+        )}
+      </View>
+      <View style={styles.footerOverlay} pointerEvents="box-none">
+        <TabFooter
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          visible={footerVisible}
+        />
+      </View>
     </SafeAreaView>
   );
 }
@@ -43,6 +67,19 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background.surface,
+  },
+  content: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  tabContent: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  footerOverlay: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    overflow: "hidden",
   },
   loader: {
     flex: 1,

--- a/src/components/quran/quran-view.tsx
+++ b/src/components/quran/quran-view.tsx
@@ -46,6 +46,7 @@ export function QuranView({
   onVerseLongPress,
   onChapterPress,
   onChapterLongPress,
+  onContentTap,
 }: QuranViewProps) {
   const { page, loading, error } = useQuranData(pageNumber);
 
@@ -152,16 +153,7 @@ export function QuranView({
 
   const handleVersePress = useCallback(
     (verse: Verse, x: number, y: number) => {
-      console.log("[QuranView] onVersePress:", {
-        verseNumber: verse.number,
-        chapterId: verse.chapter_id,
-        pageNumber,
-        position: { x, y },
-      });
-      setSelectedVerse(verse);
-      resolveChapterForVerse(verse);
-      setVersePopupVisible(true);
-
+      // Short tap: do not open popup (avoids layout shift). Parent can show footer.
       const event: VersePressEvent = {
         verse,
         page: pageNumber,
@@ -169,8 +161,9 @@ export function QuranView({
         position: { x, y },
       };
       onVersePress?.(event);
+      onContentTap?.();
     },
-    [pageNumber, onVersePress, resolveChapterForVerse],
+    [pageNumber, onVersePress, onContentTap],
   );
 
   const handleVerseLongPress = useCallback(
@@ -341,9 +334,9 @@ export function QuranView({
     });
   };
 
-  // Whenever a line is clicked, we search for a verse that has a highlight on that line number,
+  // Long press on line: find verse under tap and show popup. Short press does not open popup (use onContentTap for footer).
   // and check whether the X position of the click falls between the start and end positions of that verse’s highlight.
-  const onLineClicked = useCallback(
+  const onLineLongPress = useCallback(
     (lineIndex: number, locationX: number) => {
       const xIndex = locationX / width;
 
@@ -369,7 +362,7 @@ export function QuranView({
       resolveChapterForVerse(targetVerse);
       setVersePopupVisible(true);
     },
-    [width, page, layout, setSelectedVerse, setVersePopupVisible, resolveChapterForVerse],
+    [width, page, layout, resolveChapterForVerse],
   );
 
   const renderLines = () => {
@@ -387,11 +380,11 @@ export function QuranView({
             backgroundColor: "transparent",
             marginBottom: 4,
           }}
-          onPress={(e) => {
-            onLineClicked(i, e.nativeEvent.locationX);
+          onPress={() => {
+            onContentTap?.();
           }}
           onLongPress={(e) => {
-            onLineClicked(i, e.nativeEvent.locationX);
+            onLineLongPress(i, e.nativeEvent.locationX);
           }}
         >
           <View style={{ width, height: lineHeight, position: "absolute" }}>

--- a/src/components/quran/types.ts
+++ b/src/components/quran/types.ts
@@ -158,6 +158,8 @@ export interface QuranViewProps {
   onChapterPress?: (event: ChapterPressEvent) => void;
   onChapterLongPress?: (event: ChapterPressEvent) => void;
   onPageChange?: (page: number) => void;
+  /** Called on short tap on content (line); use to show/focus footer. Popup only opens on long press. */
+  onContentTap?: () => void;
 
   // Custom Rendering
   renderSuraNameBar?: (props: SuraNameBarProps) => React.ReactNode;

--- a/src/components/tab-footer.tsx
+++ b/src/components/tab-footer.tsx
@@ -1,0 +1,185 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import {
+  Animated,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import Feather from "@expo/vector-icons/Feather";
+import AntDesign from "@expo/vector-icons/AntDesign";
+import { colors } from "../theme";
+
+type IconComponentProps = {
+  name: string;
+  size?: number;
+  color?: string;
+};
+
+const FOOTER_HEIGHT = 100;
+const SLIDE_DURATION = 250;
+const ICON_SIZE = 22;
+const BUTTON_PADDING_VERTICAL = 8;
+const BUTTON_PADDING_HORIZONTAL = 16;
+const BORDER_RADIUS = 8;
+const BUTTON_GAP = 4;
+const FONT_SIZE = 14;
+
+export type TabId = "mushaf" | "progress";
+
+type TabConfig = {
+  id: TabId;
+  label: string;
+  Icon: React.ComponentType<IconComponentProps>;
+  iconName: string;
+};
+
+const TABS: TabConfig[] = [
+  {
+    id: "mushaf",
+    label: "المصحف",
+    Icon: Feather as React.ComponentType<IconComponentProps>,
+    iconName: "book-open",
+  },
+  {
+    id: "progress",
+    label: "التقدم",
+    Icon: AntDesign as React.ComponentType<IconComponentProps>,
+    iconName: "bar-chart",
+  },
+];
+
+type TabFooterProps = {
+  activeTab: TabId;
+  onTabChange: (tab: TabId) => void;
+  visible?: boolean;
+};
+
+function useFooterSlide(visible: boolean) {
+  const translateY = useRef(
+    new Animated.Value(visible ? 0 : FOOTER_HEIGHT),
+  ).current;
+
+  useEffect(() => {
+    Animated.timing(translateY, {
+      toValue: visible ? 0 : FOOTER_HEIGHT,
+      duration: SLIDE_DURATION,
+      useNativeDriver: true,
+    }).start();
+  }, [visible, translateY]);
+
+  return translateY;
+}
+
+type TabButtonProps = {
+  tab: TabConfig;
+  isActive: boolean;
+  onTabChange: (tab: TabId) => void;
+};
+
+const TabButton = React.memo(function TabButton({
+  tab,
+  isActive,
+  onTabChange,
+}: TabButtonProps) {
+  const handlePress = useCallback(
+    () => onTabChange(tab.id),
+    [onTabChange, tab.id],
+  );
+
+  const iconColor = isActive ? colors.brand.default : colors.text.tertiary;
+  const { Icon, iconName } = tab;
+
+  return (
+    <Pressable
+      accessibilityRole="tab"
+      accessibilityState={{ selected: isActive }}
+      accessibilityLabel={tab.label}
+      style={({ pressed }) => [
+        styles.footerButton,
+        pressed && styles.footerButtonPressed,
+      ]}
+      onPress={handlePress}
+    >
+      <View style={styles.iconWrap}>
+        <Icon
+          name={iconName}
+          size={ICON_SIZE}
+          color={iconColor}
+        />
+      </View>
+      <Text
+        style={[
+          styles.footerButtonText,
+          isActive && styles.footerButtonTextActive,
+        ]}
+      >
+        {tab.label}
+      </Text>
+    </Pressable>
+  );
+});
+
+export function TabFooter({
+  activeTab,
+  onTabChange,
+  visible = true,
+}: TabFooterProps) {
+  const translateY = useFooterSlide(visible);
+
+  return (
+    <View style={[styles.footerWrapper, { height: FOOTER_HEIGHT }]}>
+      <Animated.View
+        pointerEvents={visible ? "auto" : "none"}
+        style={[
+          styles.footer,
+          { height: FOOTER_HEIGHT, transform: [{ translateY }] },
+        ]}
+      >
+        {TABS.map((tab) => (
+          <TabButton
+            key={tab.id}
+            tab={tab}
+            isActive={activeTab === tab.id}
+            onTabChange={onTabChange}
+          />
+        ))}
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  footerWrapper: {
+    overflow: "hidden",
+  },
+  footer: {
+    backgroundColor: colors.background.surface,
+    borderTopWidth: 1,
+    borderTopColor: colors.border.default,
+    flexDirection: "row",
+    justifyContent: "space-around",
+    alignItems: "center",
+  },
+  footerButton: {
+    paddingVertical: BUTTON_PADDING_VERTICAL,
+    paddingHorizontal: BUTTON_PADDING_HORIZONTAL,
+    borderRadius: BORDER_RADIUS,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconWrap: {
+    marginBottom: BUTTON_GAP,
+  },
+  footerButtonPressed: {
+    opacity: 0.7,
+  },
+  footerButtonText: {
+    fontSize: FONT_SIZE,
+    color: colors.text.tertiary,
+    fontWeight: "600",
+  },
+  footerButtonTextActive: {
+    color: colors.brand.default,
+  },
+});

--- a/src/screens/mushaf-screen.tsx
+++ b/src/screens/mushaf-screen.tsx
@@ -6,9 +6,7 @@ import {
   View,
   ViewToken,
 } from "react-native";
-import { AudioPlayerBar } from "../components/audio-player-bar";
 import { PageJumpInput } from "../components/page-jump-input";
-import { QuranPage } from "../components/quran-page";
 import { databaseService } from "../services/sqlite-service";
 import { QuranView } from "../components/quran";
 import { colors } from "../theme";
@@ -20,13 +18,21 @@ type ViewableItemsChangedInfo = {
   viewableItems: ViewToken[];
 };
 
-export function MushafScreen() {
+type MushafScreenProps = {
+  onContentTap?: () => void;
+};
+
+export function MushafScreen({ onContentTap }: MushafScreenProps) {
   const currentChapter = useMushafStore((s) => s.currentChapter);
   const setCurrentChapter = useMushafStore((s) => s.setCurrentChapter);
   const activeVerse = useMushafStore((s) => s.activeVerse);
   const pages = Array.from({ length: 604 }, (_, i) => i + 1);
   const [currentPage, setCurrentPage] = useState(1);
   const flatListRef = useRef<FlatList<number>>(null);
+
+  const handleContentTap = useCallback(() => {
+    onContentTap?.();
+  }, [onContentTap]);
 
   async function updateChapter(pageNumber: number) {
     try {
@@ -86,10 +92,11 @@ export function MushafScreen() {
         pagingEnabled
         removeClippedSubviews
         renderItem={({ item }) => (
-          <View style={{ height: height - 60, width }}>
+          <View style={{ height, width }}>
             <QuranView
               activeChapter={currentChapter}
               activeVerse={activeVerse}
+              onContentTap={handleContentTap}
               pageNumber={item}
             />
           </View>

--- a/src/screens/progress-screen.tsx
+++ b/src/screens/progress-screen.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { colors } from "../theme";
+
+/**
+ * Placeholder for future Progress tracker.
+ * Shown when user taps "التقدم" in the footer.
+ */
+export function ProgressScreen() {
+  return <View style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background.default,
+  },
+});


### PR DESCRIPTION
# PR: Footer + Tab Navigation + Popup Gesture Change

## Summary

This is the **first branch** that introduces a **bottom footer** for the mushaf app. The footer can be **shown or hidden by tapping the screen** (toggle). It also provides **tab navigation** between the **Mushaf** view and a **Progress tracking** page (placeholder in this PR; full design will follow in a stacked PR). In addition, the **verse/chapter popup behavior** is changed: the popup now opens on **long press** (touch with a short delay) instead of on a simple tap.

---

## Demo (Tested From iPhone)

https://github.com/user-attachments/assets/76e836f9-5c38-4026-af37-cf1a04990bfa


## What’s in this PR

### 1. New bottom footer (show/hide + tabs)

- **`TabFooter`** component (`src/components/tab-footer.tsx`):
  - Two tabs: **المصحف** (Mushaf) and **التقدم** (Progress).
  - Footer **slides in/out** (animated) based on a `visible` prop.
  - Tapping a tab switches the main content between Mushaf and Progress screens.
- **App-level wiring** (`App.tsx`):
  - `footerVisible` state toggles footer visibility.
  - `activeTab` state (`"mushaf" | "progress"`) drives which screen is shown.
  - Footer is rendered as an overlay at the bottom; content area uses `pointerEvents` so taps can toggle the footer when it’s visible or pass through when hidden.

### 2. Tap-to-toggle footer, long-press for popup

- **Short tap** on mushaf content (verse marker, line, or chapter area):
  - Triggers `onContentTap` only → used to **toggle footer visibility** (and optionally other UI).
  - **Does not** open the verse/chapter popup (avoids layout shift and accidental popups).
- **Long press** (touch with a bit of delay):
  - Verse: opens **verse popup** (share, etc.).
  - Chapter/sura name: opens **chapter popup**.
  - Line: resolves verse under tap and opens **verse popup** (with position check).
- **Types** (`src/components/quran/types.ts`):
  - `QuranViewProps` includes optional `onContentTap?: () => void` with a short doc: *“Called on short tap on content (line); use to show/focus footer. Popup only opens on long press.”*

### 3. Screen wiring

- **`MushafScreen`** (`src/screens/mushaf-screen.tsx`):
  - Accepts `onContentTap` and forwards it to `QuranView` so a short tap on the page toggles the footer.
- **`ProgressScreen`** (`src/screens/progress-screen.tsx`):
  - **Placeholder only**: empty screen shown when the user selects the “التقدم” tab. Progress tracking UI and behavior will be designed and implemented in a **follow-up stacked PR**.

---

## Files touched

| File | Change |
|------|--------|
| `App.tsx` | Footer overlay, `activeTab` / `footerVisible` state, conditional render of `MushafScreen` vs `ProgressScreen`, `onContentTap` → toggle footer |
| `src/components/tab-footer.tsx` | **New**: Tab bar (Mushaf / Progress), slide animation, `TabId` type |
| `src/components/quran/quran-view.tsx` | Short tap → `onContentTap` only; long press → open verse/chapter popup; line long-press opens verse popup |
| `src/components/quran/types.ts` | Added `onContentTap` to `QuranViewProps` with JSDoc |
| `src/screens/mushaf-screen.tsx` | `onContentTap` prop and `handleContentTap` passed to `QuranView` |
| `src/screens/progress-screen.tsx` | Placeholder screen for Progress tab (real design in next PR) |

---

## Follow-up

- **Next stacked PR**: Design and implement the **Progress tracking** screen and any persistence/navigation details.

---

## Testing suggestions

- Tap mushaf content (verse, line, empty area) → footer toggles; no popup on short tap.
- Long-press verse → verse popup opens.
- Long-press chapter/sura name → chapter popup opens.
- Switch between “المصحف” and “التقدم” → correct screen shown; Progress is currently an empty placeholder.
