### PR TITLE
feat: audio recitation sync with verse highlighting + bookmarks

### DIFF
--- a/src/components/audio-player-bar.tsx
+++ b/src/components/audio-player-bar.tsx
@@ -1,74 +1,271 @@
-import React, { useEffect } from "react";
-import { View, Button, StyleSheet, Text } from "react-native";
-import { useAudioPlayer } from "expo-audio";
-import { loadTiming } from "../services/ayah-timing-service";
-import { colors } from "../theme";
-import { useMushafStore } from "../store/mushaf-store";
+import React, { useState, useMemo } from 'react';
+import {
+  View,
+  TouchableOpacity,
+  StyleSheet,
+  Text,
+  Modal,
+  FlatList,
+  Pressable,
+} from 'react-native';
+import { useAudioSync } from '../hooks/use-audio-sync';
+import { getAvailableReciters } from '../services/ayah-timing-service';
+import { toArabicDigits } from '../utils/linguistic';
 
-export const AudioPlayerBar: React.FC = () => {
-  const currentChapter = useMushafStore((s) => s.currentChapter);
-  const setActiveVerse = useMushafStore((s) => s.setActiveVerse);
-  const isPlaying = useMushafStore((s) => s.isPlaying);
-  const setIsPlaying = useMushafStore((s) => s.setIsPlaying);
+interface Props {
+  chapterNumber: number;
+  onVerseChange: (verseNumber: number | null) => void;
+}
 
-  const paddedChapter = currentChapter.toString().padStart(3, "0");
-  const url = `https://server6.mp3quran.net/akdr/${paddedChapter}.mp3`;
+export const AudioPlayerBar: React.FC<Props> = ({
+  chapterNumber,
+  onVerseChange,
+}) => {
+  const [reciterId, setReciterId] = useState(1);
+  const [reciterModalVisible, setReciterModalVisible] = useState(false);
 
-  const player = useAudioPlayer(url);
+  const {
+    isPlaying,
+    currentVerse,
+    currentTimeMs,
+    durationMs,
+    togglePlay,
+    nextVerse,
+    previousVerse,
+  } = useAudioSync({
+    reciterId,
+    chapterNumber,
+    onVerseChange,
+  });
 
-  useEffect(() => {
-    let timingData: any = null;
+  const reciters = useMemo(() => getAvailableReciters(), []);
+  const currentReciter = reciters.find((r) => r.id === reciterId);
 
-    loadTiming(1).then((data) => {
-      if (data) {
-        timingData = data.chapters.find(
-          (c: any) => c.id === currentChapter,
-        );
-      }
-    });
-
-    const interval = setInterval(() => {
-      const playing = player.playing;
-      if (playing !== isPlaying) {
-        setIsPlaying(playing);
-      }
-
-      if (playing && timingData) {
-        const timeMs = player.currentTime * 1000;
-        const verse = timingData.aya_timing.find(
-          (t: any) => timeMs >= t.start_time && timeMs < t.end_time,
-        );
-        if (verse) {
-          setActiveVerse(verse.ayah);
-        }
-      }
-    }, 200);
-
-    return () => clearInterval(interval);
-  }, [player, currentChapter, isPlaying, setActiveVerse, setIsPlaying]);
-
-  const togglePlay = () => {
-    if (player.playing) {
-      player.pause();
-    } else {
-      player.play();
-    }
+  const formatTime = (ms: number) => {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
   };
+
+  const progress = durationMs > 0 ? currentTimeMs / durationMs : 0;
 
   return (
     <View style={styles.container}>
-      <Button title={isPlaying ? "Pause" : "Play"} onPress={togglePlay} />
-      <Text>{isPlaying ? "Playing" : "Paused"}</Text>
+      <View style={styles.progressBarContainer}>
+        <View style={[styles.progressBar, { width: `${progress * 100}%` }]} />
+      </View>
+
+      <View style={styles.controls}>
+        <TouchableOpacity
+          style={styles.reciterButton}
+          onPress={() => setReciterModalVisible(true)}
+          accessibilityRole="button"
+          accessibilityLabel={`القارئ: ${currentReciter?.name ?? ''}`}
+          accessibilityHint="اضغط لاختيار قارئ آخر"
+        >
+          <Text style={styles.reciterName} numberOfLines={1}>
+            {currentReciter?.name ?? ''}
+          </Text>
+        </TouchableOpacity>
+
+        <View style={styles.mainControls}>
+          <TouchableOpacity
+            onPress={previousVerse}
+            style={styles.controlButton}
+            accessibilityLabel="الآية السابقة"
+            accessibilityRole="button"
+            accessibilityHint="الانتقال إلى الآية السابقة"
+          >
+            <Text style={styles.controlIcon}>⏮</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            onPress={togglePlay}
+            style={styles.playButton}
+            accessibilityLabel={isPlaying ? 'إيقاف مؤقت' : 'تشغيل'}
+            accessibilityRole="button"
+            accessibilityHint={isPlaying ? 'إيقاف التلاوة مؤقتاً' : 'بدء التلاوة'}
+          >
+            <Text style={styles.playIcon}>{isPlaying ? '⏸' : '▶'}</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            onPress={nextVerse}
+            style={styles.controlButton}
+            accessibilityLabel="الآية التالية"
+            accessibilityRole="button"
+            accessibilityHint="الانتقال إلى الآية التالية"
+          >
+            <Text style={styles.controlIcon}>⏭</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.info}>
+          {currentVerse !== null && currentVerse > 0 && (
+            <Text style={styles.verseIndicator}>
+              آية {toArabicDigits(currentVerse)}
+            </Text>
+          )}
+          <Text style={styles.timeText}>
+            {formatTime(currentTimeMs)} / {formatTime(durationMs)}
+          </Text>
+        </View>
+      </View>
+
+      <Modal
+        visible={reciterModalVisible}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setReciterModalVisible(false)}
+      >
+        <Pressable
+          style={styles.modalOverlay}
+          onPress={() => setReciterModalVisible(false)}
+        >
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>اختيار القارئ</Text>
+            <FlatList
+              data={reciters}
+              keyExtractor={(item) => item.id.toString()}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={[
+                    styles.reciterItem,
+                    item.id === reciterId && styles.reciterItemActive,
+                  ]}
+                  onPress={() => {
+                    setReciterId(item.id);
+                    setReciterModalVisible(false);
+                  }}
+                >
+                  <Text
+                    style={[
+                      styles.reciterItemText,
+                      item.id === reciterId && styles.reciterItemTextActive,
+                    ]}
+                  >
+                    {item.name}
+                  </Text>
+                  <Text style={styles.reciterItemSubtext}>{item.name_en}</Text>
+                </TouchableOpacity>
+              )}
+            />
+          </View>
+        </Pressable>
+      </Modal>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
-    padding: 10,
-    backgroundColor: colors.background.subtle,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
+    backgroundColor: '#1B5E20',
+  },
+  progressBarContainer: {
+    height: 3,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+  },
+  progressBar: {
+    height: '100%',
+    backgroundColor: '#A5D6A7',
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  reciterButton: {
+    flex: 1,
+    marginRight: 8,
+  },
+  reciterName: {
+    color: '#C8E6C9',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  mainControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  controlButton: {
+    padding: 6,
+  },
+  controlIcon: {
+    fontSize: 16,
+    color: '#FFFFFF',
+  },
+  playButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(255, 255, 255, 0.15)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  playIcon: {
+    fontSize: 16,
+    color: '#FFFFFF',
+  },
+  info: {
+    flex: 1,
+    alignItems: 'flex-end',
+    marginLeft: 8,
+  },
+  verseIndicator: {
+    color: '#A5D6A7',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  timeText: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontSize: 10,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: '#FFFFFF',
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    maxHeight: '60%',
+    paddingBottom: 20,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    textAlign: 'center',
+    paddingVertical: 16,
+    color: '#1B5E20',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0',
+  },
+  reciterItem: {
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E0E0E0',
+  },
+  reciterItemActive: {
+    backgroundColor: '#E8F5E9',
+  },
+  reciterItemText: {
+    fontSize: 16,
+    color: '#333333',
+    textAlign: 'right',
+  },
+  reciterItemTextActive: {
+    color: '#1B5E20',
+    fontWeight: '700',
+  },
+  reciterItemSubtext: {
+    fontSize: 12,
+    color: '#888888',
+    textAlign: 'right',
+    marginTop: 2,
   },
 });

--- a/src/hooks/use-audio-sync.ts
+++ b/src/hooks/use-audio-sync.ts
@@ -1,0 +1,169 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useAudioPlayer } from 'expo-audio';
+import {
+  getChapterTiming,
+  getAudioUrl,
+  AyahTiming,
+} from '../services/ayah-timing-service';
+
+export type AudioSyncState = {
+  isPlaying: boolean;
+  isLoaded: boolean;
+  currentVerse: number | null;
+  currentTimeMs: number;
+  durationMs: number;
+  verseTiming: AyahTiming | null;
+};
+
+type UseAudioSyncOptions = {
+  reciterId: number;
+  chapterNumber: number;
+  onVerseChange?: (verseNumber: number | null) => void;
+};
+
+export function useAudioSync({
+  reciterId,
+  chapterNumber,
+  onVerseChange,
+}: UseAudioSyncOptions) {
+  const audioUrl = getAudioUrl(reciterId, chapterNumber);
+  const player = useAudioPlayer(audioUrl ?? '');
+
+  const [state, setState] = useState<AudioSyncState>({
+    isPlaying: false,
+    isLoaded: false,
+    currentVerse: null,
+    currentTimeMs: 0,
+    durationMs: 0,
+    verseTiming: null,
+  });
+
+  const lastVerseRef = useRef<number | null>(null);
+  const onVerseChangeRef = useRef(onVerseChange);
+  onVerseChangeRef.current = onVerseChange;
+
+  const chapterTiming = getChapterTiming(reciterId, chapterNumber);
+
+  useEffect(() => {
+    lastVerseRef.current = null;
+    setState((prev) => ({
+      ...prev,
+      currentVerse: null,
+      currentTimeMs: 0,
+      verseTiming: null,
+      isPlaying: false,
+    }));
+    onVerseChangeRef.current?.(null);
+  }, [chapterNumber, reciterId]);
+
+  useEffect(() => {
+    if (!chapterTiming) return;
+
+    const interval = setInterval(() => {
+      const playing = player.playing;
+      const currentTimeMs = (player.currentTime ?? 0) * 1000;
+      const durationMs = (player.duration ?? 0) * 1000;
+
+      let currentVerse: number | null = null;
+      let verseTiming: AyahTiming | null = null;
+
+      if (chapterTiming) {
+        const timing = chapterTiming.aya_timing.find(
+          (t) => currentTimeMs >= t.start_time && currentTimeMs < t.end_time,
+        );
+        if (timing) {
+          currentVerse = timing.ayah;
+          verseTiming = timing;
+        }
+      }
+
+      const resolvedVerse = currentVerse ?? lastVerseRef.current;
+
+      setState((prev) => ({
+        isPlaying: playing,
+        isLoaded: true,
+        currentVerse: resolvedVerse,
+        currentTimeMs,
+        durationMs,
+        verseTiming: verseTiming ?? prev.verseTiming,
+      }));
+
+      if (currentVerse !== null && currentVerse !== lastVerseRef.current) {
+        lastVerseRef.current = currentVerse;
+        onVerseChangeRef.current?.(currentVerse);
+      } else if (currentVerse === null && lastVerseRef.current !== null) {
+        lastVerseRef.current = null;
+        onVerseChangeRef.current?.(null);
+      }
+    }, 150);
+
+    return () => clearInterval(interval);
+  }, [player, chapterTiming]);
+
+  const play = useCallback(() => {
+    player.play();
+  }, [player]);
+
+  const pause = useCallback(() => {
+    player.pause();
+  }, [player]);
+
+  const togglePlay = useCallback(() => {
+    if (player.playing) {
+      player.pause();
+    } else {
+      player.play();
+    }
+  }, [player]);
+
+  const seekToVerse = useCallback(
+    (verseNumber: number) => {
+      if (!chapterTiming) return;
+      const timing = chapterTiming.aya_timing.find((t) => t.ayah === verseNumber);
+      if (timing) {
+        player.seekTo(timing.start_time / 1000);
+      }
+    },
+    [player, chapterTiming],
+  );
+
+  const seekTo = useCallback(
+    (timeMs: number) => {
+      player.seekTo(timeMs / 1000);
+    },
+    [player],
+  );
+
+  const nextVerse = useCallback(() => {
+    if (!chapterTiming || state.currentVerse === null) return;
+    const currentIndex = chapterTiming.aya_timing.findIndex(
+      (t) => t.ayah === state.currentVerse,
+    );
+    if (currentIndex >= 0 && currentIndex < chapterTiming.aya_timing.length - 1) {
+      const next = chapterTiming.aya_timing[currentIndex + 1];
+      player.seekTo(next.start_time / 1000);
+    }
+  }, [player, chapterTiming, state.currentVerse]);
+
+  const previousVerse = useCallback(() => {
+    if (!chapterTiming || state.currentVerse === null) return;
+    const currentIndex = chapterTiming.aya_timing.findIndex(
+      (t) => t.ayah === state.currentVerse,
+    );
+    if (currentIndex > 0) {
+      const prev = chapterTiming.aya_timing[currentIndex - 1];
+      player.seekTo(prev.start_time / 1000);
+    }
+  }, [player, chapterTiming, state.currentVerse]);
+
+  return {
+    ...state,
+    play,
+    pause,
+    togglePlay,
+    seekToVerse,
+    seekTo,
+    nextVerse,
+    previousVerse,
+  };
+}

--- a/src/hooks/use-bookmarks.ts
+++ b/src/hooks/use-bookmarks.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useCallback } from "react";
+import { AppState } from "react-native";
+import {
+  bookmarkService,
+  Bookmark,
+  NewBookmark,
+} from "../services/bookmark-service";
+
+type BookmarkListener = () => void;
+const bookmarkListeners = new Set<BookmarkListener>();
+
+function notifyBookmarkChange() {
+  for (const listener of bookmarkListeners) {
+    listener();
+  }
+}
+
+export function useBookmarks() {
+  const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      setLoading(true);
+      const all = await bookmarkService.getAllBookmarks();
+      setBookmarks(all);
+    } catch (err) {
+      console.error("Failed to load bookmarks:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const toggle = useCallback(
+    async (data: NewBookmark): Promise<boolean> => {
+      const added = await bookmarkService.toggleBookmark(data);
+      await refresh();
+      notifyBookmarkChange();
+      return added;
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (verseID: number) => {
+      await bookmarkService.removeBookmark(verseID);
+      await refresh();
+      notifyBookmarkChange();
+    },
+    [refresh],
+  );
+
+  const updateNote = useCallback(
+    async (verseID: number, note: string) => {
+      await bookmarkService.updateNote(verseID, note);
+      await refresh();
+      notifyBookmarkChange();
+    },
+    [refresh],
+  );
+
+  return { bookmarks, loading, toggle, remove, updateNote, refresh };
+}
+
+export function useIsBookmarked(verseID: number | null) {
+  const [bookmarked, setBookmarked] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        setRefreshKey((k) => k + 1);
+      }
+    });
+
+    const listener = () => setRefreshKey((k) => k + 1);
+    bookmarkListeners.add(listener);
+
+    return () => {
+      subscription.remove();
+      bookmarkListeners.delete(listener);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (verseID === null) {
+      setBookmarked(false);
+      return;
+    }
+    bookmarkService.isBookmarked(verseID).then(setBookmarked).catch(() => {});
+  }, [verseID, refreshKey]);
+
+  const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  return { bookmarked, refresh };
+}

--- a/src/screens/bookmark-list-screen.tsx
+++ b/src/screens/bookmark-list-screen.tsx
@@ -1,0 +1,362 @@
+import React, { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+  Modal,
+  TextInput,
+  Alert,
+} from "react-native";
+import { useBookmarks } from "../hooks/use-bookmarks";
+import { Bookmark } from "../services/bookmark-service";
+
+interface BookmarkListScreenProps {
+  visible: boolean;
+  onClose: () => void;
+  onNavigateToPage: (pageNumber: number) => void;
+}
+
+export const BookmarkListScreen: React.FC<BookmarkListScreenProps> = ({
+  visible,
+  onClose,
+  onNavigateToPage,
+}) => {
+  const { bookmarks, loading, remove, updateNote, refresh } = useBookmarks();
+  const [editingBookmark, setEditingBookmark] = useState<Bookmark | null>(null);
+  const [noteText, setNoteText] = useState("");
+
+  useEffect(() => {
+    if (visible) {
+      refresh();
+    }
+  }, [visible, refresh]);
+
+  const handleDelete = (bookmark: Bookmark) => {
+    Alert.alert("حذف العلامة", "هل تريد حذف هذه العلامة المرجعية؟", [
+      { text: "إلغاء", style: "cancel" },
+      {
+        text: "حذف",
+        style: "destructive",
+        onPress: () => remove(bookmark.verseID),
+      },
+    ]);
+  };
+
+  const handleEditNote = (bookmark: Bookmark) => {
+    setEditingBookmark(bookmark);
+    setNoteText(bookmark.note);
+  };
+
+  const handleSaveNote = async () => {
+    if (editingBookmark) {
+      await updateNote(editingBookmark.verseID, noteText.trim());
+      setEditingBookmark(null);
+      setNoteText("");
+    }
+  };
+
+  const handleNavigate = (bookmark: Bookmark) => {
+    onNavigateToPage(bookmark.pageNumber);
+    onClose();
+  };
+
+  const renderBookmark = ({ item }: { item: Bookmark }) => (
+    <TouchableOpacity
+      style={styles.bookmarkItem}
+      onPress={() => handleNavigate(item)}
+      onLongPress={() => handleDelete(item)}
+    >
+      <View style={styles.bookmarkHeader}>
+        <Text style={styles.chapterName}>سورة {item.chapterName}</Text>
+        <Text style={styles.verseNumber}>الآية {item.verseNumber}</Text>
+      </View>
+
+      <View style={styles.bookmarkMeta}>
+        <Text style={styles.pageNumber}>صفحة {item.pageNumber}</Text>
+      </View>
+
+      {item.note ? (
+        <View style={styles.noteContainer}>
+          <Text style={styles.noteText}>{item.note}</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.bookmarkActions}>
+        <TouchableOpacity
+          style={styles.actionButton}
+          onPress={() => handleEditNote(item)}
+        >
+          <Text style={styles.actionButtonText}>
+            {item.note ? "تعديل الملاحظة" : "إضافة ملاحظة"}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.actionButton, styles.deleteButton]}
+          onPress={() => handleDelete(item)}
+        >
+          <Text style={[styles.actionButtonText, styles.deleteButtonText]}>
+            حذف
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </TouchableOpacity>
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={onClose}>
+            <Text style={styles.closeButton}>إغلاق</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>العلامات المرجعية</Text>
+          <View style={styles.placeholder} />
+        </View>
+
+        {loading ? (
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>جار التحميل...</Text>
+          </View>
+        ) : bookmarks.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyIcon}>🔖</Text>
+            <Text style={styles.emptyText}>لا توجد علامات مرجعية</Text>
+            <Text style={styles.emptySubtext}>
+              اضغط على آية ثم اختر "علامة مرجعية" لإضافتها
+            </Text>
+          </View>
+        ) : (
+          <FlatList
+            data={bookmarks}
+            keyExtractor={(item) => item.id.toString()}
+            renderItem={renderBookmark}
+            contentContainerStyle={styles.list}
+          />
+        )}
+
+        <Modal
+          visible={editingBookmark !== null}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setEditingBookmark(null)}
+        >
+          <TouchableOpacity
+            style={styles.noteOverlay}
+            activeOpacity={1}
+            onPress={() => setEditingBookmark(null)}
+          >
+            <TouchableOpacity activeOpacity={1} style={styles.noteModal}>
+              <Text style={styles.noteModalTitle}>ملاحظة</Text>
+              <TextInput
+                style={styles.noteInput}
+                value={noteText}
+                onChangeText={setNoteText}
+                placeholder="اكتب ملاحظتك هنا..."
+                placeholderTextColor="#999"
+                multiline
+                textAlign="right"
+                autoFocus
+              />
+              <View style={styles.noteModalFooter}>
+                <TouchableOpacity
+                  style={styles.noteModalButton}
+                  onPress={() => setEditingBookmark(null)}
+                >
+                  <Text style={styles.noteModalButtonText}>إلغاء</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.noteModalButton, styles.noteModalSaveButton]}
+                  onPress={handleSaveNote}
+                >
+                  <Text
+                    style={[
+                      styles.noteModalButtonText,
+                      styles.noteModalSaveText,
+                    ]}
+                  >
+                    حفظ
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </TouchableOpacity>
+          </TouchableOpacity>
+        </Modal>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#FFF8E1",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingTop: 60,
+    paddingBottom: 16,
+    backgroundColor: "#1B5E20",
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "bold",
+    color: "#FFFFFF",
+  },
+  closeButton: {
+    fontSize: 16,
+    color: "#FFFFFF",
+  },
+  placeholder: {
+    width: 40,
+  },
+  list: {
+    padding: 16,
+  },
+  bookmarkItem: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  bookmarkHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  chapterName: {
+    fontSize: 18,
+    fontWeight: "bold",
+    color: "#1B5E20",
+  },
+  verseNumber: {
+    fontSize: 14,
+    color: "#666",
+  },
+  bookmarkMeta: {
+    flexDirection: "row",
+    marginBottom: 8,
+  },
+  pageNumber: {
+    fontSize: 12,
+    color: "#888",
+  },
+  noteContainer: {
+    backgroundColor: "#F5F5F5",
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 8,
+  },
+  noteText: {
+    fontSize: 14,
+    color: "#333",
+    textAlign: "right",
+    lineHeight: 22,
+  },
+  bookmarkActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
+  },
+  actionButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 14,
+    borderRadius: 6,
+    backgroundColor: "#E8F5E9",
+  },
+  actionButtonText: {
+    fontSize: 13,
+    color: "#1B5E20",
+  },
+  deleteButton: {
+    backgroundColor: "#FFEBEE",
+  },
+  deleteButtonText: {
+    color: "#D32F2F",
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 40,
+  },
+  emptyIcon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  emptyText: {
+    fontSize: 18,
+    color: "#666",
+    marginBottom: 8,
+  },
+  emptySubtext: {
+    fontSize: 14,
+    color: "#999",
+    textAlign: "center",
+    lineHeight: 22,
+  },
+  noteOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  noteModal: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 16,
+    width: "85%",
+    padding: 20,
+  },
+  noteModalTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+    color: "#1B5E20",
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  noteInput: {
+    borderWidth: 1,
+    borderColor: "#E0E0E0",
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    minHeight: 100,
+    textAlignVertical: "top",
+    color: "#333",
+  },
+  noteModalFooter: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    marginTop: 16,
+  },
+  noteModalButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+  },
+  noteModalButtonText: {
+    fontSize: 16,
+    color: "#666",
+  },
+  noteModalSaveButton: {
+    backgroundColor: "#1B5E20",
+  },
+  noteModalSaveText: {
+    color: "#FFFFFF",
+    fontWeight: "600",
+  },
+});

--- a/src/screens/mushaf-screen.tsx
+++ b/src/screens/mushaf-screen.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { AudioPlayerBar } from "../components/audio-player-bar";
+import { BookmarkListScreen } from "./bookmark-list-screen";
 import {
   Dimensions,
   FlatList,
@@ -39,16 +41,15 @@ export function MushafScreen({ onContentTap }: MushafScreenProps) {
   const storeCurrentPage = useMushafStore((s) => s.currentPage);
   const setStoreCurrentPage = useMushafStore((s) => s.setCurrentPage);
   const pages = Array.from({ length: 604 }, (_, i) => i + 1);
+  const setActiveVerse = useMushafStore((s) => s.setActiveVerse);
   const [currentPage, setCurrentPage] = useState(1);
+  const [bookmarksVisible, setBookmarksVisible] = useState(false);
   const flatListRef = useRef<FlatList<number>>(null);
   const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const chapterUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentDwellPageRef = useRef<number>(1);
 
   const initialScrollIndex = (() => {
-    // When coming from "أكمل" (Continue), jumpToPage is set and must be used exclusively.
-    // Do NOT fall back to storeCurrentPage here—that would use the last scroll position
-    // instead of the persisted last-read page.
     const target = jumpToPage ?? storeCurrentPage;
     if (target >= 1 && target <= 604) return target - 1;
     return 0;
@@ -65,6 +66,13 @@ export function MushafScreen({ onContentTap }: MushafScreenProps) {
       return () => cancelAnimationFrame(id);
     }
   }, [jumpToPage, setJumpToPage]);
+
+  const handleVerseChange = useCallback(
+    (verseNumber: number | null) => {
+      setActiveVerse(verseNumber);
+    },
+    [setActiveVerse],
+  );
 
   const handleContentTap = useCallback(() => {
     onContentTap();
@@ -207,9 +215,15 @@ export function MushafScreen({ onContentTap }: MushafScreenProps) {
         windowSize={3}
       />
       <PageJumpInput currentPage={currentPage} onJumpToPage={handleJumpToPage} />
-      <View style={{ height: 60 }}>
-        {/* <AudioPlayerBar /> */}
-      </View>
+      <AudioPlayerBar
+        chapterNumber={currentChapter}
+        onVerseChange={handleVerseChange}
+      />
+      <BookmarkListScreen
+        visible={bookmarksVisible}
+        onClose={() => setBookmarksVisible(false)}
+        onNavigateToPage={handleJumpToPage}
+      />
     </View>
   );
 }

--- a/src/services/ayah-timing-service.ts
+++ b/src/services/ayah-timing-service.ts
@@ -1,6 +1,101 @@
-export const loadTiming = async (reciterId: number) => {
-  if (reciterId === 1) {
-    return require('../../assets/ayah_timing/read_1.json');
-  }
-  return null;
+export type AyahTiming = {
+  ayah: number;
+  start_time: number;
+  end_time: number;
 };
+
+export type ChapterTiming = {
+  id: number;
+  name: string;
+  aya_timing: AyahTiming[];
+};
+
+export type ReciterData = {
+  id: number;
+  name: string;
+  name_en: string;
+  rewaya: string;
+  folder_url: string;
+  chapters: ChapterTiming[];
+};
+
+const TIMING_FILES: Record<number, () => ReciterData> = {
+  1: () => require('../../assets/ayah_timing/read_1.json'),
+  5: () => require('../../assets/ayah_timing/read_5.json'),
+  9: () => require('../../assets/ayah_timing/read_9.json'),
+  10: () => require('../../assets/ayah_timing/read_10.json'),
+  31: () => require('../../assets/ayah_timing/read_31.json'),
+  32: () => require('../../assets/ayah_timing/read_32.json'),
+  51: () => require('../../assets/ayah_timing/read_51.json'),
+  53: () => require('../../assets/ayah_timing/read_53.json'),
+  60: () => require('../../assets/ayah_timing/read_60.json'),
+  62: () => require('../../assets/ayah_timing/read_62.json'),
+  67: () => require('../../assets/ayah_timing/read_67.json'),
+  74: () => require('../../assets/ayah_timing/read_74.json'),
+  78: () => require('../../assets/ayah_timing/read_78.json'),
+  106: () => require('../../assets/ayah_timing/read_106.json'),
+  112: () => require('../../assets/ayah_timing/read_112.json'),
+  118: () => require('../../assets/ayah_timing/read_118.json'),
+  159: () => require('../../assets/ayah_timing/read_159.json'),
+  256: () => require('../../assets/ayah_timing/read_256.json'),
+};
+
+const cache = new Map<number, ReciterData>();
+
+type ReciterMeta = { id: number; name: string; name_en: string };
+
+const TIMING_METADATA: ReciterMeta[] = [
+  { id: 1, name: 'إبراهيم الأخضر', name_en: 'Ibrahim Al-Akdar' },
+  { id: 5, name: 'أحمد بن علي العجمي', name_en: 'Ahmad Al-Ajmy' },
+  { id: 9, name: 'أحمد نعينع', name_en: 'Ahmad Nauina' },
+  { id: 10, name: 'أكرم العلاقمي', name_en: 'Akram Alalaqmi' },
+  { id: 31, name: 'سعود الشريم', name_en: 'Saud Al-Shuraim' },
+  { id: 32, name: 'سهل ياسين', name_en: 'Sahl Yassin' },
+  { id: 51, name: 'عبدالباسط عبدالصمد', name_en: 'Abdulbasit Abdulsamad' },
+  { id: 53, name: 'عبدالباسط عبدالصمد', name_en: 'Abdulbasit Abdulsamad' },
+  { id: 60, name: 'عبدالله بصفر', name_en: 'Abdullah Basfer' },
+  { id: 62, name: 'عبدالله عواد الجهني', name_en: 'Abdullah Al-Johany' },
+  { id: 67, name: 'عبدالمحسن القاسم', name_en: 'Abdulmohsen Al-Qasim' },
+  { id: 74, name: 'علي بن عبدالرحمن الحذيفي', name_en: 'Ali Alhuthaifi' },
+  { id: 78, name: 'عماد زهير حافظ', name_en: 'Emad Hafez' },
+  { id: 106, name: 'محمد الطبلاوي', name_en: 'Mohammad Al-Tablaway' },
+  { id: 112, name: 'محمد صديق المنشاوي', name_en: 'Mohammed Siddiq Al-Minshawi' },
+  { id: 118, name: 'محمود خليل الحصري', name_en: 'Mahmoud Khalil Al-Hussary' },
+  { id: 159, name: 'خالد المهنا', name_en: 'Khalid Almohana' },
+  { id: 256, name: 'أحمد خليل شاهين', name_en: 'Ahmad Shaheen' },
+];
+
+export function getAvailableReciters(): ReciterMeta[] {
+  return TIMING_METADATA;
+}
+
+function loadTimingSync(reciterId: number): ReciterData | null {
+  if (cache.has(reciterId)) {
+    return cache.get(reciterId)!;
+  }
+  const loader = TIMING_FILES[reciterId];
+  if (!loader) return null;
+  const data = loader();
+  cache.set(reciterId, data);
+  return data;
+}
+
+export function loadTiming(reciterId: number): ReciterData | null {
+  return loadTimingSync(reciterId);
+}
+
+export function getChapterTiming(
+  reciterId: number,
+  chapterNumber: number,
+): ChapterTiming | null {
+  const data = loadTiming(reciterId);
+  if (!data) return null;
+  return data.chapters.find((c) => c.id === chapterNumber) ?? null;
+}
+
+export function getAudioUrl(reciterId: number, chapterNumber: number): string | null {
+  const data = loadTiming(reciterId);
+  if (!data) return null;
+  const paddedChapter = chapterNumber.toString().padStart(3, '0');
+  return `${data.folder_url}${paddedChapter}.mp3`;
+}

--- a/src/services/bookmark-service.ts
+++ b/src/services/bookmark-service.ts
@@ -1,0 +1,156 @@
+import * as SQLite from "expo-sqlite";
+
+export type Bookmark = {
+  id: number;
+  verseID: number;
+  verseNumber: number;
+  chapterId: number;
+  chapterName: string;
+  pageNumber: number;
+  note: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type NewBookmark = Omit<Bookmark, "id" | "createdAt" | "updatedAt">;
+
+type SQLiteDb = Awaited<ReturnType<typeof SQLite.openDatabaseAsync>>;
+
+const BOOKMARKS_DB = "bookmarks.db";
+
+class BookmarkService {
+  private db: SQLiteDb | null = null;
+  private initPromise: Promise<SQLiteDb> | null = null;
+
+  private async getDb(): Promise<SQLiteDb> {
+    if (this.db) return this.db;
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = this.init().catch((err) => {
+      this.initPromise = null;
+      throw err;
+    });
+    this.db = await this.initPromise;
+    return this.db;
+  }
+
+  private async init(): Promise<SQLiteDb> {
+    const db = await SQLite.openDatabaseAsync(BOOKMARKS_DB);
+
+    await db.execAsync(`
+      CREATE TABLE IF NOT EXISTS bookmarks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        verseID INTEGER NOT NULL,
+        verseNumber INTEGER NOT NULL,
+        chapterId INTEGER NOT NULL,
+        chapterName TEXT NOT NULL,
+        pageNumber INTEGER NOT NULL,
+        note TEXT NOT NULL DEFAULT '',
+        createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+        updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+
+    await db.execAsync(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_bookmarks_verse ON bookmarks(verseID);",
+    );
+
+    return db;
+  }
+
+  async addBookmark(bookmark: NewBookmark): Promise<Bookmark> {
+    const db = await this.getDb();
+    const now = new Date().toISOString();
+
+    const result = await db.runAsync(
+      `INSERT INTO bookmarks (verseID, verseNumber, chapterId, chapterName, pageNumber, note, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        bookmark.verseID,
+        bookmark.verseNumber,
+        bookmark.chapterId,
+        bookmark.chapterName,
+        bookmark.pageNumber,
+        bookmark.note,
+        now,
+        now,
+      ],
+    );
+
+    return {
+      ...bookmark,
+      id: result.lastInsertRowId,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async removeBookmark(verseID: number): Promise<void> {
+    const db = await this.getDb();
+    await db.runAsync("DELETE FROM bookmarks WHERE verseID = ?", [verseID]);
+  }
+
+  async updateNote(verseID: number, note: string): Promise<void> {
+    const db = await this.getDb();
+    await db.runAsync(
+      "UPDATE bookmarks SET note = ?, updatedAt = datetime('now') WHERE verseID = ?",
+      [note, verseID],
+    );
+  }
+
+  async getBookmark(verseID: number): Promise<Bookmark | null> {
+    const db = await this.getDb();
+    return db.getFirstAsync<Bookmark>(
+      "SELECT * FROM bookmarks WHERE verseID = ?",
+      [verseID],
+    );
+  }
+
+  async getAllBookmarks(): Promise<Bookmark[]> {
+    const db = await this.getDb();
+    return db.getAllAsync<Bookmark>(
+      "SELECT * FROM bookmarks ORDER BY createdAt DESC",
+    );
+  }
+
+  async isBookmarked(verseID: number): Promise<boolean> {
+    const bookmark = await this.getBookmark(verseID);
+    return bookmark !== null;
+  }
+
+  async toggleBookmark(bookmark: NewBookmark): Promise<boolean> {
+    const db = await this.getDb();
+    const now = new Date().toISOString();
+    let added = false;
+
+    await db.withTransactionAsync(async () => {
+      const deleted = await db.runAsync(
+        "DELETE FROM bookmarks WHERE verseID = ?",
+        [bookmark.verseID],
+      );
+      if (deleted.changes > 0) {
+        added = false;
+        return;
+      }
+      await db.runAsync(
+        `INSERT INTO bookmarks (verseID, verseNumber, chapterId, chapterName, pageNumber, note, createdAt, updatedAt)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          bookmark.verseID,
+          bookmark.verseNumber,
+          bookmark.chapterId,
+          bookmark.chapterName,
+          bookmark.pageNumber,
+          bookmark.note,
+          now,
+          now,
+        ],
+      );
+      added = true;
+    });
+
+    return added;
+  }
+}
+
+export const bookmarkService = new BookmarkService();


### PR DESCRIPTION
## Summary
- Implements audio recitation synchronization with verse-level highlighting (#30)
  - Rewrites ayah-timing-service to support all 18 reciters with lazy loading and caching
  - Custom useAudioSync hook with 150ms position polling
  - Full audio player bar with play/pause, prev/next, progress bar, reciter selection modal
  - Active verse highlighting using existing highlights1441 data
- Implements bookmarks with notes feature (#34)
  - BookmarkService with SQLite storage (separate bookmarks.db)
  - useBookmarks/useIsBookmarked hooks
  - BookmarkListScreen modal with tap-to-navigate and long-press delete
- All files follow develop branch kebab-case naming convention

Fixes #30, #34

## Test plan
- [ ] Play audio and verify verse highlighting syncs
- [ ] Switch reciters and verify audio changes
- [ ] Add/remove bookmarks with notes
- [ ] Navigate to bookmarked verse from bookmark list