### PR TITLE
Implement tab navigation layout with footer and screen management

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import { Tabs, useRouter, useSegments } from "expo-router";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { TabFooter, type TabId } from "../../src/components/tab-footer";
+import { useUiStore } from "../../src/store/ui-store";
+import { colors } from "../../src/theme";
+
+/** Tab route paths: explicit (tabs) routes for reliable tab switching (no remount). */
+const ROUTES = {
+  mushaf: "/(tabs)",
+  progress: "/(tabs)/progress",
+} as const;
+
+export default function TabsLayout() {
+  const segments = useSegments();
+  const router = useRouter();
+  const footerVisible = useUiStore((s) => s.footerVisible);
+
+  const activeTab = useMemo<TabId>(() => {
+    const tabSegment = segments[segments.length - 1];
+    return tabSegment === "progress" ? "progress" : "mushaf";
+  }, [segments]);
+
+  const handleTabChange = useCallback(
+    (tab: TabId) => {
+      if (tab === activeTab) return;
+      router.navigate(ROUTES[tab]);
+    },
+    [activeTab, router],
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        {/* Keep both tabs mounted so tab switch and Continue Reading are instant (no remount). */}
+        <Tabs
+          detachInactiveScreens={false}
+          screenOptions={{
+            headerShown: false,
+            sceneStyle: { backgroundColor: "transparent" },
+          }}
+          tabBar={() => null}
+        >
+          <Tabs.Screen
+            name="index"
+            options={{ title: "المصحف" }}
+          />
+          <Tabs.Screen
+            name="progress"
+            options={{ title: "التقدم" }}
+          />
+        </Tabs>
+      </View>
+      <View style={styles.footerOverlay} pointerEvents="box-none">
+        <TabFooter
+          activeTab={activeTab}
+          onTabChange={handleTabChange}
+          visible={footerVisible}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background.surface,
+  },
+  content: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  footerOverlay: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    overflow: "hidden",
+  },
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 
-import { MushafScreen } from "../src/screens/mushaf-screen";
-import { useUiStore } from "../src/store/ui-store";
+import { MushafScreen } from "../../src/screens/mushaf-screen";
+import { useUiStore } from "../../src/store/ui-store";
 
 export default function MushafRoute() {
   const toggleFooterVisible = useUiStore((s) => s.toggleFooterVisible);

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,8 +1,8 @@
 import { useCallback } from "react";
 import { useRouter } from "expo-router";
 
-import { ProgressScreen } from "../src/screens/progress-screen";
-import { useMushafStore } from "../src/store/mushaf-store";
+import { ProgressScreen } from "../../src/screens/progress-screen";
+import { useMushafStore } from "../../src/store/mushaf-store";
 
 export default function ProgressRoute() {
   const router = useRouter();
@@ -13,7 +13,7 @@ export default function ProgressRoute() {
     (page: number) => {
       setJumpToPage(page);
       setCurrentPage(page);
-      router.navigate("/");
+      router.navigate("/(tabs)");
     },
     [router, setCurrentPage, setJumpToPage],
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,64 +1,17 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
-import { Stack, usePathname, useRouter } from "expo-router";
+import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
-import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useFonts } from "expo-font";
 import { Amiri_400Regular } from "@expo-google-fonts/amiri";
 
-import { TabFooter, type TabId } from "../src/components/tab-footer";
 import { useMushafStore } from "../src/store/mushaf-store";
-import { useUiStore } from "../src/store/ui-store";
 import { getLastRead } from "../src/services/last-read-service";
-import { colors } from "../src/theme";
 
 SplashScreen.preventAutoHideAsync().catch(() => undefined);
 SplashScreen.setOptions({ fade: true, duration: 1000 });
-
-function AppNavigator() {
-  const pathname = usePathname();
-  const router = useRouter();
-  const footerVisible = useUiStore((s) => s.footerVisible);
-
-  const activeTab = useMemo<TabId>(
-    () => (pathname === "/progress" ? "progress" : "mushaf"),
-    [pathname],
-  );
-
-  const handleTabChange = useCallback(
-    (tab: TabId) => {
-      if (tab === activeTab) return;
-      router.navigate(tab === "progress" ? "/progress" : "/");
-    },
-    [activeTab, router],
-  );
-
-  return (
-    <SafeAreaView style={styles.container}>
-      <StatusBar style="dark" />
-      <View style={styles.content}>
-        <Stack
-          screenOptions={{
-            headerShown: false,
-            animation: "none",
-            contentStyle: { backgroundColor: "transparent" },
-          }}
-        >
-          <Stack.Screen name="index" />
-          <Stack.Screen name="progress" />
-        </Stack>
-      </View>
-      <View style={styles.footerOverlay} pointerEvents="box-none">
-        <TabFooter
-          activeTab={activeTab}
-          onTabChange={handleTabChange}
-          visible={footerVisible}
-        />
-      </View>
-    </SafeAreaView>
-  );
-}
 
 export default function RootLayout() {
   const [appReady, setAppReady] = useState(false);
@@ -92,26 +45,15 @@ export default function RootLayout() {
 
   return (
     <SafeAreaProvider>
-      <AppNavigator />
+      <StatusBar style="dark" />
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="(tabs)" />
+      </Stack>
     </SafeAreaProvider>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.background.surface,
-  },
-  content: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  footerOverlay: {
-    position: "absolute",
-    left: 0,
-    right: 0,
-    bottom: 0,
-    overflow: "hidden",
-  },
   loader: {
     flex: 1,
     alignItems: "center",


### PR DESCRIPTION
# PR: Tab navigation layout (Issue #66)

## Summary
Implements a tab-based navigation layout with a persistent footer and proper screen management. Root layout is simplified; tab UI and routing live in a dedicated `(tabs)` group.

## Changes

| File | Change |
|------|--------|
| `app/(tabs)/_layout.tsx` | **New** – Tab layout with Expo Router `Tabs`, `TabFooter`, and explicit routes for Mushaf and Progress |
| `app/(tabs)/index.tsx` | Moved from `app/index.tsx`; import paths updated |
| `app/(tabs)/progress.tsx` | Moved from `app/progress.tsx`; import paths updated; navigate target set to `/(tabs)` |
| `app/_layout.tsx` | Simplified: removed inline tab/footer logic; now renders a single `Stack` with `(tabs)` screen |

## Technical details
- **Tab routing:** Uses `ROUTES` (`/(tabs)` and `/(tabs)/progress`) so tab switching is reliable and does not remount screens.
- **Instant switching:** `detachInactiveScreens={false}` keeps both tabs mounted for fast switching and instant “Continue Reading” behavior.
- **Footer:** `TabFooter` is shown in an overlay at the bottom, visibility controlled by `useUiStore().footerVisible`.
- **Root layout:** Only handles fonts, last-read restore, and a `Stack` that mounts the `(tabs)` group; no `SafeAreaView`/footer in root.

## Diff summary (vs `develop`)
```
4 files changed, 94 insertions(+), 70 deletions(-)
```

## Testing
- [ ] Navigate between Mushaf and Progress via footer tabs.
- [ ] Confirm “Continue Reading” from Progress opens Mushaf without remount delay.
- [ ] Confirm footer visibility toggle still works.
