### PR TITLE
Implement footer auto-hide based on user activity in UI

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -4,6 +4,7 @@ import { Tabs, useRouter, useSegments } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { TabFooter, type TabId } from "../../src/components/tab-footer";
+import { useFooterAutoHide } from "../../src/hooks/use-footer-auto-hide";
 import { useUiStore } from "../../src/store/ui-store";
 import { colors } from "../../src/theme";
 
@@ -17,6 +18,8 @@ export default function TabsLayout() {
   const segments = useSegments();
   const router = useRouter();
   const footerVisible = useUiStore((s) => s.footerVisible);
+
+  useFooterAutoHide();
 
   const activeTab = useMemo<TabId>(() => {
     const tabSegment = segments[segments.length - 1];

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,11 +4,17 @@ import { MushafScreen } from "../../src/screens/mushaf-screen";
 import { useUiStore } from "../../src/store/ui-store";
 
 export default function MushafRoute() {
-  const toggleFooterVisible = useUiStore((s) => s.toggleFooterVisible);
+  const footerVisible = useUiStore((s) => s.footerVisible);
+  const setFooterVisible = useUiStore((s) => s.setFooterVisible);
+  const reportUserActivity = useUiStore((s) => s.reportUserActivity);
 
   const handleContentTap = useCallback(() => {
-    toggleFooterVisible();
-  }, [toggleFooterVisible]);
+    if (footerVisible) {
+      setFooterVisible(false);
+    } else {
+      reportUserActivity();
+    }
+  }, [footerVisible, setFooterVisible, reportUserActivity]);
 
   return <MushafScreen onContentTap={handleContentTap} />;
 }

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -3,11 +3,15 @@ import { useRouter } from "expo-router";
 
 import { ProgressScreen } from "../../src/screens/progress-screen";
 import { useMushafStore } from "../../src/store/mushaf-store";
+import { useUiStore } from "../../src/store/ui-store";
 
 export default function ProgressRoute() {
   const router = useRouter();
   const setJumpToPage = useMushafStore((s) => s.setJumpToPage);
   const setCurrentPage = useMushafStore((s) => s.setCurrentPage);
+  const footerVisible = useUiStore((s) => s.footerVisible);
+  const setFooterVisible = useUiStore((s) => s.setFooterVisible);
+  const reportUserActivity = useUiStore((s) => s.reportUserActivity);
 
   const handleContinueReading = useCallback(
     (page: number) => {
@@ -18,5 +22,15 @@ export default function ProgressRoute() {
     [router, setCurrentPage, setJumpToPage]
   );
 
-  return <ProgressScreen onContinueReading={handleContinueReading} />;
+  const handleContentTap = useCallback(() => {
+    if (footerVisible) {
+      setFooterVisible(false);
+    } else {
+      reportUserActivity();
+    }
+  }, [footerVisible, setFooterVisible, reportUserActivity]);
+
+  return (
+    <ProgressScreen onContinueReading={handleContinueReading} onContentTap={handleContentTap} />
+  );
 }

--- a/src/hooks/use-footer-auto-hide.ts
+++ b/src/hooks/use-footer-auto-hide.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+import { useUiStore, FOOTER_AUTO_HIDE_DELAY_MS } from "../store/ui-store";
+
+/**
+ * Subscribes to user activity and hides the footer after a period of inactivity.
+ * Call reportUserActivity() from screens when the user taps; that shows the
+ * footer and resets the auto-hide timer.
+ */
+export function useFooterAutoHide() {
+  const lastActivityAt = useUiStore((s) => s.lastActivityAt);
+  const footerVisible = useUiStore((s) => s.footerVisible);
+  const setFooterVisible = useUiStore((s) => s.setFooterVisible);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!footerVisible) return;
+
+    const scheduleHide = () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null;
+        setFooterVisible(false);
+      }, FOOTER_AUTO_HIDE_DELAY_MS);
+    };
+
+    scheduleHide();
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [lastActivityAt, footerVisible, setFooterVisible]);
+}

--- a/src/screens/progress-screen.tsx
+++ b/src/screens/progress-screen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from "react-native";
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ContinueReadingCard } from "../components/continue-reading-card";
 import { OverallProgress } from "../components/overall-progress";
@@ -11,6 +11,8 @@ import { colors } from "../theme";
 
 type ProgressScreenProps = {
   onContinueReading?: (page: number) => void;
+  /** Called when user taps the screen (e.g. to show/hide bottom nav). */
+  onContentTap?: () => void;
 };
 
 type LastReadWithChapter = LastRead & {
@@ -34,7 +36,7 @@ function ProgressEmpty() {
   );
 }
 
-export function ProgressScreen({ onContinueReading }: ProgressScreenProps) {
+export function ProgressScreen({ onContinueReading, onContentTap }: ProgressScreenProps) {
   const insets = useSafeAreaInsets();
   const [lastReadData, setLastReadData] = useState<LastReadWithChapter | null>(null);
   const [readCount, setReadCount] = useState(0);
@@ -106,7 +108,7 @@ export function ProgressScreen({ onContinueReading }: ProgressScreenProps) {
     );
   };
 
-  return (
+  const scrollContent = (
     <ScrollView
       style={styles.container}
       contentContainerStyle={[styles.content, { paddingTop: insets.top + 24 }]}
@@ -115,6 +117,16 @@ export function ProgressScreen({ onContinueReading }: ProgressScreenProps) {
       {renderContent()}
     </ScrollView>
   );
+
+  if (onContentTap) {
+    return (
+      <Pressable style={styles.container} onPress={onContentTap} accessible={false}>
+        {scrollContent}
+      </Pressable>
+    );
+  }
+
+  return scrollContent;
 }
 
 const styles = StyleSheet.create({

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -1,13 +1,34 @@
 import { create } from "zustand";
 
+/** Delay (ms) before auto-hiding the footer after last user activity. */
+export const FOOTER_AUTO_HIDE_DELAY_MS = 2500;
+
+/** Min ms between activity updates to avoid excessive timer rescheduling on rapid taps. */
+const ACTIVITY_DEBOUNCE_MS = 150;
+
 type UiState = {
   footerVisible: boolean;
+  /** Timestamp of last user activity; used by auto-hide timer to reset. */
+  lastActivityAt: number;
   setFooterVisible: (visible: boolean) => void;
   toggleFooterVisible: () => void;
+  /** Call when user interacts (e.g. tap). Shows footer and resets auto-hide timer. */
+  reportUserActivity: () => void;
 };
 
 export const useUiStore = create<UiState>((set) => ({
-  footerVisible: false,
+  footerVisible: true,
+  lastActivityAt: 0,
   setFooterVisible: (visible) => set({ footerVisible: visible }),
   toggleFooterVisible: () => set((state) => ({ footerVisible: !state.footerVisible })),
+  reportUserActivity: () =>
+    set((state) => {
+      const now = Date.now();
+      if (state.footerVisible && now - state.lastActivityAt < ACTIVITY_DEBOUNCE_MS) {
+        return state;
+      }
+      return state.footerVisible
+        ? { lastActivityAt: now }
+        : { footerVisible: true, lastActivityAt: now };
+    }),
 }));


### PR DESCRIPTION
# Auto-hide bottom navigation during reading

Closes [#68](https://github.com/adelpro/mushaf-imad-expo/issues/68#issue-4049833076).

---

## Summary

Implements auto-hide behavior for the bottom tab bar: it hides after a short period of inactivity and reappears on user interaction. **Mushaf** and **Progress** use the same tap behavior: tap toggles the bar (hide when visible, show + reset timer when hidden) so the bar can always be brought back when auto-hidden.

---

## Behavior

| Context | Auto-hide | On tap |
|--------|-----------|--------|
| **Mushaf** | Footer hides after 2.5 s of no interaction. | Tap **toggles**: hide if visible, show + reset timer if hidden. |
| **Progress** | Same 2.5 s timer when footer is visible. | Tap **toggles**: hide if visible, show + reset timer if hidden. |

- **Transition:** Existing `TabFooter` slide animation (250 ms) is used; no new UI.
- **Initial state:** Footer is visible on app load; timer starts and auto-hides after 2.5 s if there is no interaction.

---

<details>
<summary><strong>Implementation</strong></summary>

### 1. Store (`src/store/ui-store.ts`)

- **State:** `footerVisible` (default `true`), `lastActivityAt` (timestamp for timer reset).
- **Actions:**
  - `reportUserActivity()` — Shows footer (if hidden) and updates `lastActivityAt` to reset the auto-hide timer. Used on tap from screens.
  - `setFooterVisible(boolean)` / `toggleFooterVisible()` — Used for tap-to-toggle on both Mushaf and Progress, and manual control.
- **Constants:** `FOOTER_AUTO_HIDE_DELAY_MS = 2500` (exported for reuse/settings). `ACTIVITY_DEBOUNCE_MS = 150` (internal, for debouncing rapid taps).

### 2. Hook (`src/hooks/use-footer-auto-hide.ts`)

- **Role:** When `footerVisible` is true, schedules a single timeout to call `setFooterVisible(false)` after `FOOTER_AUTO_HIDE_DELAY_MS`. Any new activity (via `reportUserActivity`) updates `lastActivityAt` and reschedules the timeout.
- **Usage:** Invoked once in the tabs layout; no props or screen-specific logic.

### 3. Layout (`app/(tabs)/_layout.tsx`)

- Renders `TabFooter` with `visible={footerVisible}` from the store.
- Calls `useFooterAutoHide()` so the auto-hide timer runs for the active tab.

### 4. Mushaf (`app/(tabs)/index.tsx` + `src/screens/mushaf-screen.tsx`)

- Mushaf route passes `onContentTap` with the same toggle logic as Progress: if footer visible → `setFooterVisible(false)`; if hidden → `reportUserActivity()`.
- Existing `MushafScreen` content tap handler calls `onContentTap`; tap toggles the footer and resets the auto-hide timer when showing.

### 5. Progress (`app/(tabs)/progress.tsx` + `src/screens/progress-screen.tsx`)

- Progress route passes `onContentTap`: if footer visible → `setFooterVisible(false)`; if hidden → `reportUserActivity()` (same as Mushaf).
- `ProgressScreen` accepts optional `onContentTap`; when provided, wraps content in a `Pressable` that fires it so tap can show/hide the bar. When not provided, behavior is unchanged (no wrapper).

</details>

---

## Optional enhancements (out of scope for this PR)

The following optional enhancements from the original issue **will not be implemented in this PR**:

- **Configurable delay timer** — Allow the user to change how long before the footer auto-hides (e.g. 2 s, 3 s, 5 s).
- **Disable the feature in settings** — Allow the user to turn auto-hide on or off via a preference.

The delay is currently a single constant in code (`FOOTER_AUTO_HIDE_DELAY_MS`); it is not user-configurable. Consider creating a **new issue** to implement a settings screen (or section) where users can:
- Enable or disable the auto-hide behavior.
- Choose the auto-hide delay (e.g. via preset options or a slider).

---

## Testing

- **Mushaf:** Open app → wait ~2.5 s → footer hides. Tap content → footer appears; tap again to hide, or wait ~2.5 s for auto-hide. Same toggle behavior as Progress.
- **Progress:** With footer visible, tap to hide. With footer hidden, tap to show; it auto-hides again after ~2.5 s. Rapid taps do not cause visible jank or excessive timer churn.
