### PR TITLE
Enhance QuranView with zoom, pan, and improved gesture handling

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useFonts } from "expo-font";
 import { Amiri_400Regular } from "@expo-google-fonts/amiri";
@@ -54,41 +55,47 @@ export default function RootLayout() {
 
   if (appReady) {
     return (
-      <SafeAreaProvider>
-        <StatusBar style="dark" />
-        <Stack screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="(tabs)" />
-        </Stack>
-      </SafeAreaProvider>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <SafeAreaProvider>
+          <StatusBar style="dark" />
+          <Stack screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="(tabs)" />
+          </Stack>
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
     );
   }
 
   if (isFirstLaunch) {
     return (
-      <SafeAreaProvider>
-        <View style={styles.splash}>
-          <LottieView
-            source={require("../assets/animations/mushaf.json")}
-            autoPlay
-            loop
-            style={styles.lottie}
-          />
-          <ActivityIndicator size="large" color={colors.brand.default} style={styles.spinner} />
-          <Text style={styles.message}>
-            جارٍ تجهيز المصحف…{"\n"}
-            سيكون جاهزاً في لحظات
-          </Text>
-        </View>
-      </SafeAreaProvider>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <SafeAreaProvider>
+          <View style={styles.splash}>
+            <LottieView
+              source={require("../assets/animations/mushaf.json")}
+              autoPlay
+              loop
+              style={styles.lottie}
+            />
+            <ActivityIndicator size="large" color={colors.brand.default} style={styles.spinner} />
+            <Text style={styles.message}>
+              جارٍ تجهيز المصحف…{"\n"}
+              سيكون جاهزاً في لحظات
+            </Text>
+          </View>
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
     );
   }
 
   return (
-    <SafeAreaProvider>
-      <View style={styles.loader}>
-        <ActivityIndicator size="large" color={colors.brand.default} />
-      </View>
-    </SafeAreaProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <View style={styles.loader}>
+          <ActivityIndicator size="large" color={colors.brand.default} />
+        </View>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -42,10 +42,13 @@
     "lottie-react-native": "~7.3.1",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-gesture-handler": "~2.28.0",
+    "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
+    "react-native-worklets": "0.5.1",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/src/components/quran/index.ts
+++ b/src/components/quran/index.ts
@@ -2,6 +2,7 @@
 
 export { QuranView } from "./quran-view";
 export { useQuranData } from "./use-quran-data";
+export { useZoomPan } from "./use-zoom-pan";
 export { VersePopup } from "./verse-popup";
 export { ChapterPopup } from "./chapter-popup";
 

--- a/src/components/quran/quran-view.tsx
+++ b/src/components/quran/quran-view.tsx
@@ -13,6 +13,8 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { GestureDetector } from "react-native-gesture-handler";
+import Animated from "react-native-reanimated";
 import { captureRef } from "react-native-view-shot";
 import SuraNameBar from "../../../assets/images/sura_name_bar.svg";
 import { QuranImages } from "../../constants/image-map";
@@ -33,6 +35,7 @@ import {
   VersePressEvent,
 } from "./types";
 import { useQuranData } from "./use-quran-data";
+import { useZoomPan } from "./use-zoom-pan";
 import { VersePopup } from "./verse-popup";
 
 const { width } = Dimensions.get("window");
@@ -52,6 +55,7 @@ export function QuranView({
   onChapterPress,
   onChapterLongPress,
   onContentTap,
+  isViewable = false,
 }: QuranViewProps) {
   const { page, loading, error } = useQuranData(pageNumber);
 
@@ -74,6 +78,18 @@ export function QuranView({
   const faselWidth = 21 * faselBalance * lineScale;
   const faselHeight = 27 * faselBalance * lineScale;
   const faselCenterYOffset = config.verseMarkerCenterYOffset * lineScale;
+
+  const contentHeightMax = (lineHeight + LINE_GAP) * config.lineCount - LINE_GAP;
+  const isCentered = pageNumber === 1 || pageNumber === 2;
+  const lineCount = isCentered ? 9 : config.lineCount;
+  const contentHeight = (lineHeight + LINE_GAP) * lineCount - LINE_GAP;
+
+  const { gesture, animatedStyle, getContentX } = useZoomPan({
+    width,
+    contentHeight,
+    contentHeightMax,
+    isViewable,
+  });
 
   const resolveLineImage = useCallback(
     (lineIndex: number) => {
@@ -332,7 +348,8 @@ export function QuranView({
   const onLineLongPress = useCallback(
     (lineIndex: number, locationX: number) => {
       triggerImpactHaptic();
-      const xIndex = locationX / width;
+      const contentX = getContentX(locationX);
+      const xIndex = Math.max(0, Math.min(1, contentX / width));
 
       if (!page) return;
 
@@ -352,7 +369,7 @@ export function QuranView({
       resolveChapterForVerse(targetVerse);
       setVersePopupVisible(true);
     },
-    [width, page, layout, resolveChapterForVerse]
+    [width, page, layout, resolveChapterForVerse, getContentX]
   );
 
   const renderLines = () => {
@@ -418,16 +435,19 @@ export function QuranView({
     );
   }
 
-  const isCentered = pageNumber === 1 || pageNumber === 2;
-
   return (
     <View style={styles.container}>
       <ScrollView
         contentContainerStyle={[styles.linesContainer, isCentered && styles.centeredContent]}
         showsVerticalScrollIndicator={true}
         indicatorStyle="black"
+        nestedScrollEnabled
       >
-        {renderLines()}
+        <GestureDetector gesture={gesture}>
+          <Animated.View style={[{ width, height: contentHeight }, animatedStyle]}>
+            {renderLines()}
+          </Animated.View>
+        </GestureDetector>
       </ScrollView>
 
       <VersePopup

--- a/src/components/quran/types.ts
+++ b/src/components/quran/types.ts
@@ -153,6 +153,9 @@ export interface QuranViewProps {
   activeChapter?: number;
   activeVerse?: number | null;
 
+  /** When true, this page is the currently visible one; zoom is reset when becoming visible. */
+  isViewable?: boolean;
+
   // Callbacks
   onVersePress?: (event: VersePressEvent) => void;
   onVerseLongPress?: (event: VersePressEvent) => void;

--- a/src/components/quran/use-zoom-pan.ts
+++ b/src/components/quran/use-zoom-pan.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { Gesture } from "react-native-gesture-handler";
+import { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 4;
+const SETTLE_DURATION_MS = 120;
+
+export type UseZoomPanParams = {
+  width: number;
+  contentHeight: number;
+  contentHeightMax: number;
+  isViewable: boolean;
+};
+
+export type UseZoomPanResult = {
+  gesture: ReturnType<typeof Gesture.Simultaneous>;
+  animatedStyle: Record<string, unknown>;
+  /** Convert touch locationX (view coords) to content X for verse hit detection. Use when zoomed. */
+  getContentX: (locationX: number) => number;
+};
+
+export function useZoomPan({
+  width,
+  contentHeight,
+  contentHeightMax,
+  isViewable,
+}: UseZoomPanParams): UseZoomPanResult {
+  const zoomScaleRef = useRef(1);
+  const zoomTranslateXRef = useRef(0);
+  const zoomTranslateYRef = useRef(0);
+  const prevViewableRef = useRef(false);
+
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const savedTranslateX = useSharedValue(0);
+  const savedTranslateY = useSharedValue(0);
+
+  const updateZoomRefs = useCallback((s: number, tx: number, ty: number) => {
+    zoomScaleRef.current = s;
+    zoomTranslateXRef.current = tx;
+    zoomTranslateYRef.current = ty;
+  }, []);
+
+  useEffect(() => {
+    const leftScreen = !isViewable && prevViewableRef.current;
+    prevViewableRef.current = isViewable;
+    if (!leftScreen) return;
+
+    scale.value = 1;
+    savedScale.value = 1;
+    translateX.value = 0;
+    translateY.value = 0;
+    savedTranslateX.value = 0;
+    savedTranslateY.value = 0;
+    updateZoomRefs(1, 0, 0);
+  }, [
+    isViewable,
+    scale,
+    savedScale,
+    translateX,
+    translateY,
+    savedTranslateX,
+    savedTranslateY,
+    updateZoomRefs,
+  ]);
+
+  const pinchGesture = useMemo(
+    () =>
+      Gesture.Pinch()
+        .onUpdate((e) => {
+          const nextScale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, savedScale.value * e.scale));
+          const dx = e.focalX - width / 2;
+          const dy = e.focalY - contentHeight / 2;
+          let tx = dx * (1 - nextScale);
+          let ty = dy * (1 - nextScale);
+          const maxTx = (width * (nextScale - 1)) / 2;
+          const maxTy = (contentHeightMax * (nextScale - 1)) / 2;
+          tx = Math.max(-maxTx, Math.min(maxTx, tx));
+          ty = Math.max(-maxTy, Math.min(maxTy, ty));
+          scale.value = nextScale;
+          translateX.value = tx;
+          translateY.value = ty;
+        })
+        .onEnd(() => {
+          const s = scale.value;
+          const tx = translateX.value;
+          const ty = translateY.value;
+          scale.value = withTiming(s, { duration: SETTLE_DURATION_MS });
+          translateX.value = withTiming(tx, { duration: SETTLE_DURATION_MS });
+          translateY.value = withTiming(ty, { duration: SETTLE_DURATION_MS });
+          savedScale.value = withTiming(s, { duration: SETTLE_DURATION_MS });
+          savedTranslateX.value = tx;
+          savedTranslateY.value = ty;
+          runOnJS(updateZoomRefs)(s, tx, ty);
+        }),
+    [updateZoomRefs, width, contentHeight, contentHeightMax]
+  );
+
+  const panGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .failOffsetX([-20, 20])
+        .activeOffsetY(10)
+        .onUpdate((e) => {
+          if (scale.value <= MIN_ZOOM) return;
+          const maxTx = (width * (scale.value - 1)) / 2;
+          const maxTy = (contentHeightMax * (scale.value - 1)) / 2;
+          translateX.value = Math.max(
+            -maxTx,
+            Math.min(maxTx, savedTranslateX.value + e.translationX)
+          );
+          translateY.value = Math.max(
+            -maxTy,
+            Math.min(maxTy, savedTranslateY.value + e.translationY)
+          );
+        })
+        .onEnd(() => {
+          const tx = translateX.value;
+          const ty = translateY.value;
+          translateX.value = withTiming(tx, { duration: SETTLE_DURATION_MS });
+          translateY.value = withTiming(ty, { duration: SETTLE_DURATION_MS });
+          savedTranslateX.value = tx;
+          savedTranslateY.value = ty;
+          runOnJS(updateZoomRefs)(scale.value, tx, ty);
+        }),
+    [updateZoomRefs, width, contentHeightMax]
+  );
+
+  const composedGesture = useMemo(
+    () => Gesture.Simultaneous(pinchGesture, panGesture),
+    [pinchGesture, panGesture]
+  );
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: scale.value },
+    ],
+  }));
+
+  const getContentX = useCallback((locationX: number) => {
+    const s = zoomScaleRef.current;
+    const tx = zoomTranslateXRef.current;
+    if (s <= 0) return locationX - tx;
+    return (locationX - tx) / s;
+  }, []);
+
+  return {
+    gesture: composedGesture,
+    animatedStyle,
+    getContentX,
+  };
+}

--- a/src/screens/mushaf-screen.tsx
+++ b/src/screens/mushaf-screen.tsx
@@ -186,6 +186,7 @@ export function MushafScreen({ onContentTap }: MushafScreenProps) {
             <QuranView
               activeChapter={currentChapter}
               activeVerse={activeVerse}
+              isViewable={currentPage === item}
               onContentTap={handleContentTap}
               pageNumber={item}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5493,12 +5493,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-haptics@npm:~15.0.8":
-  version: 15.0.8
-  resolution: "expo-haptics@npm:15.0.8"
+"expo-haptics@npm:^55.0.8":
+  version: 55.0.8
+  resolution: "expo-haptics@npm:55.0.8"
   peerDependencies:
     expo: "*"
-  checksum: 10c0/25f58bbbb5faa0d05701ada7f1247adead98a7e30dcbac136aa3e458773584ac758318a02d906de7ba85d63cbd45e7edde3dc35e61825f0dc1e8ed20668ed594
+  checksum: 10c0/0fa41ddf5fb271fd66b9ea033ec124985b95f5bd3d9e18b488ecf2574cd410c18e861691ac2ac9b87c761dec14d9ac2f31601da6a15434a97802ea0f8bff525a
   languageName: node
   linkType: hard
 
@@ -7463,7 +7463,7 @@ __metadata:
     expo-constants: "npm:~18.0.13"
     expo-file-system: "npm:^19.0.21"
     expo-font: "npm:~14.0.11"
-    expo-haptics: "npm:~15.0.8"
+    expo-haptics: "npm:^55.0.8"
     expo-linking: "npm:~8.0.11"
     expo-router: "npm:~6.0.23"
     expo-sharing: "npm:~14.0.8"
@@ -7475,7 +7475,6 @@ __metadata:
     lottie-react-native: "npm:~7.3.1"
     prettier: "npm:^3.8.1"
     react: "npm:19.1.0"
-    react-dom: "npm:19.1.0"
     react-native: "npm:0.81.5"
     react-native-gesture-handler: "npm:~2.28.0"
     react-native-reanimated: "npm:~4.1.1"
@@ -8197,17 +8196,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:19.1.0":
-  version: 19.1.0
-  resolution: "react-dom@npm:19.1.0"
-  dependencies:
-    scheduler: "npm:^0.26.0"
-  peerDependencies:
-    react: ^19.1.0
-  checksum: 10c0/3e26e89bb6c67c9a6aa86cb888c7a7f8258f2e347a6d2a15299c17eb16e04c19194e3452bc3255bd34000a61e45e2cb51e46292392340432f133e5a5d2dfb5fc
-  languageName: node
-  linkType: hard
-
 "react-fast-compare@npm:^3.2.2":
   version: 3.2.2
   resolution: "react-fast-compare@npm:3.2.2"
@@ -8820,7 +8808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:0.26.0, scheduler@npm:^0.26.0":
+"scheduler@npm:0.26.0":
   version: 0.26.0
   resolution: "scheduler@npm:0.26.0"
   checksum: 10c0/5b8d5bfddaae3513410eda54f2268e98a376a429931921a81b5c3a2873aab7ca4d775a8caac5498f8cbc7d0daeab947cf923dbd8e215d61671f9f4e392d34356

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,7 +559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-arrow-functions@npm:^7.24.7":
+"@babel/plugin-transform-arrow-functions@npm:^7.0.0-0, @babel/plugin-transform-arrow-functions@npm:^7.24.7":
   version: 7.27.1
   resolution: "@babel/plugin-transform-arrow-functions@npm:7.27.1"
   dependencies:
@@ -607,7 +607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-properties@npm:^7.25.4":
+"@babel/plugin-transform-class-properties@npm:^7.0.0-0, @babel/plugin-transform-class-properties@npm:^7.25.4":
   version: 7.28.6
   resolution: "@babel/plugin-transform-class-properties@npm:7.28.6"
   dependencies:
@@ -631,7 +631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-classes@npm:^7.25.4":
+"@babel/plugin-transform-classes@npm:^7.0.0-0, @babel/plugin-transform-classes@npm:^7.25.4":
   version: 7.28.6
   resolution: "@babel/plugin-transform-classes@npm:7.28.6"
   dependencies:
@@ -765,7 +765,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7":
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.0.0-0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7":
   version: 7.28.6
   resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.28.6"
   dependencies:
@@ -813,7 +813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-chaining@npm:^7.24.8":
+"@babel/plugin-transform-optional-chaining@npm:^7.0.0-0, @babel/plugin-transform-optional-chaining@npm:^7.24.8":
   version: 7.28.6
   resolution: "@babel/plugin-transform-optional-chaining@npm:7.28.6"
   dependencies:
@@ -959,7 +959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-shorthand-properties@npm:^7.24.7":
+"@babel/plugin-transform-shorthand-properties@npm:^7.0.0-0, @babel/plugin-transform-shorthand-properties@npm:^7.24.7":
   version: 7.27.1
   resolution: "@babel/plugin-transform-shorthand-properties@npm:7.27.1"
   dependencies:
@@ -993,6 +993,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-template-literals@npm:^7.0.0-0":
+  version: 7.27.1
+  resolution: "@babel/plugin-transform-template-literals@npm:7.27.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.27.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/c90f403e42ef062b60654d1c122c70f3ec6f00c2f304b0931ebe6d0b432498ef8a5ef9266ddf00debc535f8390842207e44d3900eff1d2bab0cc1a700f03e083
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-typescript@npm:^7.25.2, @babel/plugin-transform-typescript@npm:^7.28.5":
   version: 7.28.6
   resolution: "@babel/plugin-transform-typescript@npm:7.28.6"
@@ -1008,7 +1019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-regex@npm:^7.24.7":
+"@babel/plugin-transform-unicode-regex@npm:^7.0.0-0, @babel/plugin-transform-unicode-regex@npm:^7.24.7":
   version: 7.27.1
   resolution: "@babel/plugin-transform-unicode-regex@npm:7.27.1"
   dependencies:
@@ -1036,7 +1047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.23.0":
+"@babel/preset-typescript@npm:^7.16.7, @babel/preset-typescript@npm:^7.23.0":
   version: 7.28.5
   resolution: "@babel/preset-typescript@npm:7.28.5"
   dependencies:
@@ -1091,6 +1102,15 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10c0/54a6a9813e48ef6f35aa73c03b3c1572cad7fa32b61b35dd07e4230bc77b559194519c8a4d8106a041a27cc7a94052579e238a30a32d5509aa4da4d6fd83d990
+  languageName: node
+  linkType: hard
+
+"@egjs/hammerjs@npm:^2.0.17":
+  version: 2.0.17
+  resolution: "@egjs/hammerjs@npm:2.0.17"
+  dependencies:
+    "@types/hammerjs": "npm:^2.0.36"
+  checksum: 10c0/dbedc15a0e633f887c08394bd636faf6a3abd05726dc0909a0e01209d5860a752d9eca5e512da623aecfabe665f49f1d035de3103eb2f9022c5cea692f9cc9be
   languageName: node
   linkType: hard
 
@@ -3271,6 +3291,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/235d2fc69741448e853333b7c3d1180a966dd2b8972c8cbcd6b2a0c6cd7f8d582ab2b8e58219dbc62cce8f1b40aa317ff78ea2201cdd8249da5025adebed6f0b
+  languageName: node
+  linkType: hard
+
+"@types/hammerjs@npm:^2.0.36":
+  version: 2.0.46
+  resolution: "@types/hammerjs@npm:2.0.46"
+  checksum: 10c0/f3c1cb20dc2f0523f7b8c76065078544d50d8ae9b0edc1f62fed657210ed814266ff2dfa835d2c157a075991001eec3b64c88bf92e3e6e895c0db78d05711d06
   languageName: node
   linkType: hard
 
@@ -5466,12 +5493,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-haptics@npm:^55.0.8":
-  version: 55.0.8
-  resolution: "expo-haptics@npm:55.0.8"
+"expo-haptics@npm:~15.0.8":
+  version: 15.0.8
+  resolution: "expo-haptics@npm:15.0.8"
   peerDependencies:
     expo: "*"
-  checksum: 10c0/0fa41ddf5fb271fd66b9ea033ec124985b95f5bd3d9e18b488ecf2574cd410c18e861691ac2ac9b87c761dec14d9ac2f31601da6a15434a97802ea0f8bff525a
+  checksum: 10c0/25f58bbbb5faa0d05701ada7f1247adead98a7e30dcbac136aa3e458773584ac758318a02d906de7ba85d63cbd45e7edde3dc35e61825f0dc1e8ed20668ed594
   languageName: node
   linkType: hard
 
@@ -6088,6 +6115,15 @@ __metadata:
   dependencies:
     hermes-estree: "npm:0.32.0"
   checksum: 10c0/5902d2c5d347c0629fba07a47eaad5569590ac69bc8bfb2e454e08d2dfbe1ebd989d88518dca2cba64061689b5eac5960ae6bd15a4a66600bbf377498a3234b7
+  languageName: node
+  linkType: hard
+
+"hoist-non-react-statics@npm:^3.3.0":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: "npm:^16.7.0"
+  checksum: 10c0/fe0889169e845d738b59b64badf5e55fa3cf20454f9203d1eb088df322d49d4318df774828e789898dcb280e8a5521bb59b3203385662ca5e9218a6ca5820e74
   languageName: node
   linkType: hard
 
@@ -7427,7 +7463,7 @@ __metadata:
     expo-constants: "npm:~18.0.13"
     expo-file-system: "npm:^19.0.21"
     expo-font: "npm:~14.0.11"
-    expo-haptics: "npm:^55.0.8"
+    expo-haptics: "npm:~15.0.8"
     expo-linking: "npm:~8.0.11"
     expo-router: "npm:~6.0.23"
     expo-sharing: "npm:~14.0.8"
@@ -7439,12 +7475,16 @@ __metadata:
     lottie-react-native: "npm:~7.3.1"
     prettier: "npm:^3.8.1"
     react: "npm:19.1.0"
+    react-dom: "npm:19.1.0"
     react-native: "npm:0.81.5"
+    react-native-gesture-handler: "npm:~2.28.0"
+    react-native-reanimated: "npm:~4.1.1"
     react-native-safe-area-context: "npm:~5.6.0"
     react-native-screens: "npm:~4.16.0"
     react-native-svg: "npm:15.12.1"
     react-native-svg-transformer: "npm:^1.5.1"
     react-native-view-shot: "npm:4.0.3"
+    react-native-worklets: "npm:0.5.1"
     rimraf: "npm:^6.1.3"
     typescript: "npm:~5.9.2"
     typescript-eslint: "npm:^8.56.0"
@@ -8157,6 +8197,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-dom@npm:19.1.0":
+  version: 19.1.0
+  resolution: "react-dom@npm:19.1.0"
+  dependencies:
+    scheduler: "npm:^0.26.0"
+  peerDependencies:
+    react: ^19.1.0
+  checksum: 10c0/3e26e89bb6c67c9a6aa86cb888c7a7f8258f2e347a6d2a15299c17eb16e04c19194e3452bc3255bd34000a61e45e2cb51e46292392340432f133e5a5d2dfb5fc
+  languageName: node
+  linkType: hard
+
 "react-fast-compare@npm:^3.2.2":
   version: 3.2.2
   resolution: "react-fast-compare@npm:3.2.2"
@@ -8173,6 +8224,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^16.7.0":
+  version: 16.13.1
+  resolution: "react-is@npm:16.13.1"
+  checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.0.0":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
@@ -8184,6 +8242,20 @@ __metadata:
   version: 19.2.4
   resolution: "react-is@npm:19.2.4"
   checksum: 10c0/477a7cfc900f24194606e315fa353856a3a13487ea8eca841678817cad4daef64339ea0d1e84e58459fc75dbe0d9ba00bb0cc626db3d07e0cf31edc64cb4fa37
+  languageName: node
+  linkType: hard
+
+"react-native-gesture-handler@npm:~2.28.0":
+  version: 2.28.0
+  resolution: "react-native-gesture-handler@npm:2.28.0"
+  dependencies:
+    "@egjs/hammerjs": "npm:^2.0.17"
+    hoist-non-react-statics: "npm:^3.3.0"
+    invariant: "npm:^2.2.4"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/4240c8eedca69eb36b5d3e375b71867251cf8b87a755ba7066b3f73cfdbc80574042dbd4ff821041fd1539c4cd90dbf7ee34586f5a0ea6cc38052375b3169f2e
   languageName: node
   linkType: hard
 
@@ -8204,6 +8276,21 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/87d20b900aded7d44c90afb946a7aa03c23a94ca3dd547bdddc2303b85357e4aab22567a57b19f1558d6c8be7058e3dcf34faa1e15182d1604f90974266d9a1d
+  languageName: node
+  linkType: hard
+
+"react-native-reanimated@npm:~4.1.1":
+  version: 4.1.6
+  resolution: "react-native-reanimated@npm:4.1.6"
+  dependencies:
+    react-native-is-edge-to-edge: "npm:^1.2.1"
+    semver: "npm:7.7.2"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+    react: "*"
+    react-native: "*"
+    react-native-worklets: ">=0.5.0"
+  checksum: 10c0/924b3a3fc0e6b47b97491122689bc00d59c5c2abf90ba05dd811f1c6d59efb8fb83135e4fa4463241ff937450025b7b335af54ab5f35c15197efaaef90235e91
   languageName: node
   linkType: hard
 
@@ -8269,6 +8356,29 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/e172507eb7de8760a8a557a5e8632bdc248b60b89770cc941690c8fe6c788d28be1efd8259236fbc768eba3b33aaec8b7a833476b566dfef5b754618060edbec
+  languageName: node
+  linkType: hard
+
+"react-native-worklets@npm:0.5.1":
+  version: 0.5.1
+  resolution: "react-native-worklets@npm:0.5.1"
+  dependencies:
+    "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
+    "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
+    "@babel/plugin-transform-classes": "npm:^7.0.0-0"
+    "@babel/plugin-transform-nullish-coalescing-operator": "npm:^7.0.0-0"
+    "@babel/plugin-transform-optional-chaining": "npm:^7.0.0-0"
+    "@babel/plugin-transform-shorthand-properties": "npm:^7.0.0-0"
+    "@babel/plugin-transform-template-literals": "npm:^7.0.0-0"
+    "@babel/plugin-transform-unicode-regex": "npm:^7.0.0-0"
+    "@babel/preset-typescript": "npm:^7.16.7"
+    convert-source-map: "npm:^2.0.0"
+    semver: "npm:7.7.2"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/9eb9e6dea9abaf889400a6618355ef59af3075f5004a4bec9e4cba6dcfd13d8b63de0d4b29d75c00a3dcf5ad422e1bdb71636c75b1a2ad1c43d8b512f198bdab
   languageName: node
   linkType: hard
 
@@ -8710,10 +8820,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:0.26.0":
+"scheduler@npm:0.26.0, scheduler@npm:^0.26.0":
   version: 0.26.0
   resolution: "scheduler@npm:0.26.0"
   checksum: 10c0/5b8d5bfddaae3513410eda54f2268e98a376a429931921a81b5c3a2873aab7ca4d775a8caac5498f8cbc7d0daeab947cf923dbd8e215d61671f9f4e392d34356
+  languageName: node
+  linkType: hard
+
+"semver@npm:7.7.2":
+  version: 7.7.2
+  resolution: "semver@npm:7.7.2"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/aca305edfbf2383c22571cb7714f48cadc7ac95371b4b52362fb8eeffdfbc0de0669368b82b2b15978f8848f01d7114da65697e56cd8c37b0dab8c58e543f9ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Pinch-to-zoom on Quran pages with accurate verse hit-boxes

**Closes [#31](https://github.com/adelpro/mushaf-imad-expo/issues/31)** — Implement Pinch-to-Zoom on Quran Pages with Accurate Verse Hit-Boxes

---

## Summary

Adds pinch-to-zoom and pan on Mushaf pages. Verse marker taps and line long-press stay accurate at any zoom/pan. Horizontal page swiping is unchanged so users can still swipe left/right to change pages.

---

## What’s included

| Feature | Description |
|--------|-------------|
| **Pinch-to-zoom** |  anchored at pinch focal point (between fingers). |
| **Pan** | When zoomed; translation clamped so content stays on screen. |
| **Verse hit-boxes** | Markers and line long-press resolve correctly at any zoom/pan. |
| **Page swipe** | Horizontal swipes still change pages; zoom/pan only for pinch/vertical/diagonal. |
| **Zoom reset** | When leaving a page, zoom/pan reset off-screen so returning shows 1× with no jump. |

---

## Technical approach

- **Single zoomable wrapper**: Page content (lines, headers, markers, highlights) is in one Reanimated `Animated.View` with a single transform (`translateX`, `translateY`, `scale`). All interactives are inside it, so hit-testing stays correct.
- **Gestures (RNGH + Reanimated)**: `Gesture.Pinch()` with focal-point zoom; `Gesture.Pan()` only when `scale > 1`, with `failOffsetX([-20, 20])` and `activeOffsetY(10)` so horizontal swipes go to the FlatList. `Gesture.Simultaneous(pinch, pan)` for zoom + drag. Ease-out with `withTiming(..., { duration: 120 })` on end.
- **Line long-press**: Content-space coords via `getContentX(locationX)` → `(locationX - translateX) / scale`; verse lookup unchanged.
- **Reset on leave**: Parent passes `isViewable={currentPage === item}`; `useEffect` in `QuranView` resets scale/translate when `isViewable` goes `true` → `false`.
- **Android**: Inner `ScrollView` uses `nestedScrollEnabled` to avoid gesture/scroll conflict.
- **`useZoomPan` hook**: Holds shared values, refs, gestures, reset, animated style, and `getContentX`; keeps `QuranView` focused on layout/UI.

---

## Dependencies

| Package | Version | Purpose |
|---------|---------|---------|
| `react-native-gesture-handler` | ~2.28.0 | Pinch & pan gestures |
| `react-native-reanimated` | ~4.1.1 | Animated transform on UI thread |
| `react-native-worklets` | 0.5.1 | Reanimated 4.x Babel plugin |


---

## Files changed

| File | Change |
|------|--------|
| `app/_layout.tsx` | Wrap app in `GestureHandlerRootView`. |
| `src/components/quran/use-zoom-pan.ts` | **New** — zoom/pan state, pinch/pan gestures, reset on leave, `getContentX`. |
| `src/components/quran/quran-view.tsx` | Use `useZoomPan`; `GestureDetector` + `Animated.View`; line long-press uses `getContentX`; `ScrollView` with `nestedScrollEnabled`. |
| `src/components/quran/types.ts` | Add `isViewable?: boolean` to `QuranViewProps`. |
| `src/components/quran/index.ts` | Export `useZoomPan`. |
| `src/screens/mushaf-screen.tsx` | Pass `isViewable={currentPage === item}` to each `QuranView`. |
| `package.json` | Add RNGH, Reanimated, react-native-worklets. |

---

## Testing

1. **Pinch** — Pinch in/out; zoom around fingers; scale persists after release.
2. **Pan** — Zoom in, drag; page pans with clamped edges.
3. **Verse markers** — Tap verse numbers and long-press lines at 1× and zoomed; correct verse every time.
4. **Page swipe** — Swipe left/right to change pages; same after opening Progress or after zooming (no freeze).
5. **Mixed** — Zoom in → horizontal swipe changes page; vertical swipe pans.
6. **Reset** — Zoom in → go to next page → go back; first page is at 1× (reset happened off-screen).

---
